### PR TITLE
Upgrade to Spring Cloud Greenwich.M3

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -112,7 +112,7 @@ initializr:
             version: Greenwich.M1
             repositories: spring-milestones
           - versionRange: "[2.1.0.RELEASE,2.1.x.BUILD-SNAPSHOT)"
-            version: Greenwich.M2
+            version: Greenwich.M3
             repositories: spring-milestones
           - versionRange: "2.1.x.BUILD-SNAPSHOT"
             version: Greenwich.BUILD-SNAPSHOT


### PR DESCRIPTION
We had to do a quick release for some missing merges, so in effect, there is no M2.