### PR TITLE
Upgrade to MyBatis 2.0.0 and 1.3.3

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -476,8 +476,10 @@ initializr:
           groupId: org.mybatis.spring.boot
           artifactId: mybatis-spring-boot-starter
           mappings:
-            - versionRange: 1.5.0.RELEASE
-              version: 1.3.2
+            - versionRange: "[1.5.0.RELEASE,2.0.0.RELEASE]"
+              version: 1.3.3
+            - versionRange: 2.0.0.RELEASE
+              version: 2.0.0
         - name: PostgreSQL
           id: postgresql
           description: PostgreSQL JDBC driver


### PR DESCRIPTION
The mybatis-spring-boot has been released new versions at now.

* 2.0.0 : Supports Spring Boot 2.x
* 1.3.3 : Supports Spring Boot 1.5.x
