### PR TITLE
Skip YAML binding for SSL integration test that doesn't need it

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,6 +27,12 @@
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-web</artifactId>
+			<exclusions>
+				<exclusion>
+					<groupId>org.hibernate.validator</groupId>
+					<artifactId>hibernate-validator</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 
 		<dependency>
@@ -45,12 +51,6 @@
 		<dependency>
 			<groupId>org.ehcache</groupId>
 			<artifactId>ehcache</artifactId>
-		</dependency>
-
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-devtools</artifactId>
-			<optional>true</optional>
 		</dependency>
 
 		<dependency>

--- a/src/test/java/io/spring/start/site/StartApplicationHttpsTests.java
+++ b/src/test/java/io/spring/start/site/StartApplicationHttpsTests.java
@@ -41,7 +41,9 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Stephane Nicoll
  */
 @RunWith(SpringJUnit4ClassRunner.class)
-@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT, properties = "initializr.env.force-ssl=true")
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT, properties = {
+		"initializr.env.force-ssl=true",
+		"spring.config.location=file:./src/test/resources/application-test.yml" })
 @AutoConfigureCache
 public class StartApplicationHttpsTests {
 

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,0 +1,28 @@
+local:
+  gcp:
+    version: 1.1.0.M3
+
+logging:
+  level:
+    org.springframework.core.env: warn
+    org.springframework.jndi: warn
+
+server:
+  compression:
+    enabled: true
+    mime-types: application/json,text/css,text/html
+    min-response-size: 2048
+  use-forward-headers: true
+
+spring:
+  jackson:
+    serialization:
+     write-dates-as-timestamps: false
+  resources:
+    chain:
+      strategy:
+        content:
+          enabled: true
+  task:
+    execution:
+      thread-name-prefix: initializr-


### PR DESCRIPTION
Shaves about 1.5sec off the test suite (out of 13).