### PR TITLE
upgrade to Azure Spring Boot starters BOM 2.1.6

### DIFF
--- a/start-site/src/main/resources/application.yml
+++ b/start-site/src/main/resources/application.yml
@@ -40,7 +40,7 @@ initializr:
           - versionRange: "[2.0.0.RELEASE,2.1.0.RELEASE)"
             version: 2.0.10
           - versionRange: "2.1.0.RELEASE"
-            version: 2.1.2
+            version: 2.1.6
       codecentric-spring-boot-admin:
         groupId: de.codecentric
         artifactId: spring-boot-admin-dependencies


### PR DESCRIPTION
2.1.6 is the latest release at the time of this writing, and this will allow to use the latest Cosmos DB API and be consistent with https://github.com/microsoft/azure-spring-boot/pull/674 (and I will reference all of this from the official Azure documentation)