### PR TITLE
Generate src/main/resources/db/changelog directory when Liquibase is selected

### DIFF
--- a/start-site/src/main/java/io/spring/start/site/extension/LiquibaseProjectContributor.java
+++ b/start-site/src/main/java/io/spring/start/site/extension/LiquibaseProjectContributor.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2012-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.spring.start.site.extension;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import io.spring.initializr.generator.project.contributor.ProjectContributor;
+
+/**
+ * A {@link ProjectContributor} that creates the "db/changelog" resources directory when
+ * Liquibase is requested.
+ *
+ * @author Eddú Meléndez
+ */
+public class LiquibaseProjectContributor implements ProjectContributor {
+
+	@Override
+	public void contribute(Path projectRoot) throws IOException {
+		Path changelogDirectory = projectRoot.resolve("src/main/resources/db/changelog");
+		Files.createDirectories(changelogDirectory);
+	}
+
+}

--- a/start-site/src/main/java/io/spring/start/site/extension/StartProjectGenerationConfiguration.java
+++ b/start-site/src/main/java/io/spring/start/site/extension/StartProjectGenerationConfiguration.java
@@ -37,6 +37,7 @@ import org.springframework.context.annotation.Import;
  *
  * @author Madhura Bhave
  * @author Stephane Nicoll
+ * @author Eddú Meléndez
  */
 @ProjectGenerationConfiguration
 @Import({ SpringBootProjectGenerationConfiguration.class, SpringCloudProjectGenerationConfiguration.class,
@@ -98,6 +99,12 @@ public class StartProjectGenerationConfiguration {
 	@ConditionalOnRequestedDependency("flyway")
 	public FlywayProjectContributor flywayProjectContributor() {
 		return new FlywayProjectContributor();
+	}
+
+	@Bean
+	@ConditionalOnRequestedDependency("liquibase")
+	public LiquibaseProjectContributor liquibaseProjectContributor() {
+		return new LiquibaseProjectContributor();
 	}
 
 	@Bean

--- a/start-site/src/test/java/io/spring/start/site/extension/LiquibaseProjectContributorTests.java
+++ b/start-site/src/test/java/io/spring/start/site/extension/LiquibaseProjectContributorTests.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2012-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.spring.start.site.extension;
+
+import io.spring.initializr.generator.test.project.ProjectStructure;
+import io.spring.initializr.web.project.ProjectRequest;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link LiquibaseProjectContributor}.
+ *
+ * @author Eddú Meléndez
+ */
+class LiquibaseProjectContributorTests extends AbstractExtensionTests {
+
+	@Test
+	void liquibaseMigrationDirectoryIsCreatedWithFlyway() {
+		ProjectRequest request = createProjectRequest("web", "liquibase");
+		ProjectStructure structure = generateProject(request);
+		assertThat(structure.getProjectDirectory().resolve("src/main/resources/db/changelog")).exists().isDirectory();
+	}
+
+	@Test
+	void liquibaseMigrationDirectoryIsNotCreatedIfFlywayIsNotRequested() {
+		ProjectRequest request = createProjectRequest("web");
+		ProjectStructure structure = generateProject(request);
+		assertThat(structure.getProjectDirectory().resolve("src/main/resources/db")).doesNotExist();
+	}
+
+}


### PR DESCRIPTION
Allow to create folder `db/changelog` when liquibase dependency is
selected.