### PR TITLE
Upgrade to MyBatis Spring 2.1.0

### DIFF
--- a/start-site/src/main/resources/application.yml
+++ b/start-site/src/main/resources/application.yml
@@ -468,8 +468,10 @@ initializr:
           mappings:
             - versionRange: "[1.5.0.RELEASE,2.0.0.RELEASE)"
               version: 1.3.4
-            - versionRange: 2.0.0.RELEASE
+            - versionRange: "[2.0.0.RELEASE,2.1.0.RELEASE)"
               version: 2.0.1
+            - versionRange: 2.1.0.RELEASE
+              version: 2.1.0
         - name: PostgreSQL Driver
           id: postgresql
           description: An open source JDBC driver that allows Java programs to connect to a PostgreSQL database using standard, database independent Java code.


### PR DESCRIPTION
The [mybatis-spring-boot 2.1.0](https://github.com/mybatis/spring-boot-starter/releases/tag/mybatis-spring-boot-2.1.0) has been released at just now. This version is required Spring boot 2.1+(We tests it using Spring Boot 2.2.0.BUILD-SNAPSHOT on Travis CI).