### PR TITLE
Adding "cross-env" in fix and lint scripts in package.json

### DIFF
--- a/start-client/package.json
+++ b/start-client/package.json
@@ -17,8 +17,8 @@
     "prestart": "yarn run clean",
     "start": "gatsby develop",
     "serve": "gatsby serve",
-    "fix": "NODE_ENV=test import-sort --write '(src|utils|plugins)/**/*.js' && prettier --write '**/*.{{c,le,sc}ss,g?(raph)ql,htm?(l),js?(on|on5|onl|x|s),md?(x|wn),m?(ark)down,mkdn,ts?(x),vue,y?(a)ml}'",
-    "lint": "NODE_ENV=test import-sort -l '(src|utils|plugins)/**/*.js' && prettier --check 'src/**/*.{{c,le,sc}ss,g?(raph)ql,htm?(l),js?(on|on5|onl|x|s),md?(x|wn),m?(ark)down,mkdn,ts?(x),vue,y?(a)ml}'",
+    "fix": "cross-env NODE_ENV=test import-sort --write \"(src|utils|plugins)/**/*.js\" && prettier --write \"**/*.{{c,le,sc}ss,g?(raph)ql,htm?(l),js?(on|on5|onl|x|s),md?(x|wn),m?(ark)down,mkdn,ts?(x),vue,y?(a)ml}\"",
+    "lint": "cross-env NODE_ENV=test import-sort -l \"(src|utils|plugins)/**/*.js\" && prettier --check \"src/**/*.{{c,le,sc}ss,g?(raph)ql,htm?(l),js?(on|on5|onl|x|s),md?(x|wn),m?(ark)down,mkdn,ts?(x),vue,y?(a)ml}\"",
     "test": "echo \"Write tests! -> https://gatsby.dev/unit-testing\""
   },
   "dependencies": {


### PR DESCRIPTION
These scripts don't work on Windows without using cross-env. I also replaced single quotes to double quotes in these scripts because single quotes don't work on Windows