### PR TITLE
Align spring cloud contract plugin configuration with JUnit generation

### DIFF
--- a/start-site/src/main/java/io/spring/start/site/extension/dependency/springcloud/SpringCloudContractGradleBuildCustomizer.java
+++ b/start-site/src/main/java/io/spring/start/site/extension/dependency/springcloud/SpringCloudContractGradleBuildCustomizer.java
@@ -28,10 +28,13 @@ import org.apache.commons.logging.LogFactory;
  * with Gradle.
  *
  * @author Olga Maciaszek-Sharma
+ * @author Eddú Meléndez
  */
 class SpringCloudContractGradleBuildCustomizer implements BuildCustomizer<GradleBuild> {
 
 	private static final Log logger = LogFactory.getLog(SpringCloudContractGradleBuildCustomizer.class);
+
+	private static final Version VERSION_2_2_0 = Version.parse("2.2.0.RELEASE");
 
 	private final ProjectDescription description;
 
@@ -57,6 +60,14 @@ class SpringCloudContractGradleBuildCustomizer implements BuildCustomizer<Gradle
 		build.buildscript((buildscript) -> buildscript
 				.dependency("org.springframework.cloud:spring-cloud-contract-gradle-plugin:" + sccPluginVersion));
 		build.plugins().apply("spring-cloud-contract");
+		if (isSpringBootVersionAtLeastAfter()) {
+			build.tasks().customize("contracts", (task) -> task.attribute("targetFramework",
+					"org.springframework.cloud.contract.verifier.config.TestFramework.JUNIT5"));
+		}
+	}
+
+	private boolean isSpringBootVersionAtLeastAfter() {
+		return (VERSION_2_2_0.compareTo(this.description.getPlatformVersion()) <= 0);
 	}
 
 }

--- a/start-site/src/main/java/io/spring/start/site/extension/dependency/springcloud/SpringCloudContractMavenBuildCustomizer.java
+++ b/start-site/src/main/java/io/spring/start/site/extension/dependency/springcloud/SpringCloudContractMavenBuildCustomizer.java
@@ -28,10 +28,13 @@ import org.apache.commons.logging.LogFactory;
  * with Maven.
  *
  * @author Olga Maciaszek-Sharma
+ * @author Eddú Meléndez
  */
 class SpringCloudContractMavenBuildCustomizer implements BuildCustomizer<MavenBuild> {
 
 	private static final Log logger = LogFactory.getLog(SpringCloudContractMavenBuildCustomizer.class);
+
+	private static final Version VERSION_2_2_0 = Version.parse("2.2.0.RELEASE");
 
 	private final ProjectDescription description;
 
@@ -54,8 +57,16 @@ class SpringCloudContractMavenBuildCustomizer implements BuildCustomizer<MavenBu
 							+ bootVersion.toString());
 			return;
 		}
-		mavenBuild.plugins().add("org.springframework.cloud", "spring-cloud-contract-maven-plugin",
-				(plugin) -> plugin.extensions(true).version(sccPluginVersion));
+		mavenBuild.plugins().add("org.springframework.cloud", "spring-cloud-contract-maven-plugin", (plugin) -> {
+			plugin.extensions(true).version(sccPluginVersion);
+			if (isSpringBootVersionAtLeastAfter()) {
+				plugin.configuration((builder) -> builder.add("testFramework", "JUNIT5"));
+			}
+		});
+	}
+
+	private boolean isSpringBootVersionAtLeastAfter() {
+		return (VERSION_2_2_0.compareTo(this.description.getPlatformVersion()) <= 0);
 	}
 
 }

--- a/start-site/src/test/java/io/spring/start/site/extension/dependency/springcloud/SpringCloudContractGradleBuildCustomizerTests.java
+++ b/start-site/src/test/java/io/spring/start/site/extension/dependency/springcloud/SpringCloudContractGradleBuildCustomizerTests.java
@@ -27,6 +27,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  *
  * @author Olga Maciaszek-Sharma
  * @author Madhura Bhave
+ * @author Eddú Meléndez
  */
 class SpringCloudContractGradleBuildCustomizerTests extends AbstractExtensionTests {
 
@@ -48,6 +49,23 @@ class SpringCloudContractGradleBuildCustomizerTests extends AbstractExtensionTes
 				.doesNotContain("buildscript {",
 						"classpath 'org.springframework.cloud:spring-cloud-contract-gradle-plugin:")
 				.doesNotContain("apply plugin: 'spring-cloud-contract'");
+	}
+
+	@Test
+	void springCloudContractVerifierPluginForSpringBoot21WithNoAdditionalConfiguration() {
+		ProjectRequest projectRequest = createProjectRequest("cloud-contract-verifier");
+		projectRequest.setType("gradle-project");
+		projectRequest.setBootVersion("2.1.0.RELEASE");
+		assertThat(gradleBuild(projectRequest)).doesNotContain("testFramework");
+	}
+
+	@Test
+	void springCloudContractVerifierPluginForSpringBoot220WithJUnit5ByDefault() {
+		ProjectRequest projectRequest = createProjectRequest("cloud-contract-verifier");
+		projectRequest.setType("gradle-project");
+		projectRequest.setBootVersion("2.2.0.RELEASE");
+		assertThat(gradleBuild(projectRequest)).containsSubsequence("contracts {",
+				"targetFramework = org.springframework.cloud.contract.verifier.config.TestFramework.JUNIT5");
 	}
 
 }

--- a/start-site/src/test/java/io/spring/start/site/extension/dependency/springcloud/SpringCloudContractMavenBuildCustomizerTests.java
+++ b/start-site/src/test/java/io/spring/start/site/extension/dependency/springcloud/SpringCloudContractMavenBuildCustomizerTests.java
@@ -27,6 +27,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  *
  * @author Olga Maciaszek-Sharma
  * @author Madhura Bhave
+ * @author Eddú Meléndez
  */
 class SpringCloudContractMavenBuildCustomizerTests extends AbstractExtensionTests {
 
@@ -43,6 +44,24 @@ class SpringCloudContractMavenBuildCustomizerTests extends AbstractExtensionTest
 	void springCloudContractVerifierPluginNotAddedWhenSCCDependencyAbsent() {
 		ProjectRequest projectRequest = createProjectRequest();
 		assertThat(mavenPom(projectRequest)).doesNotContain("spring-cloud-contract-maven-plugin");
+	}
+
+	@Test
+	void springCloudContractVerifierPluginForSpringBoot21WithNoAdditionalConfiguration() {
+		ProjectRequest projectRequest = createProjectRequest("cloud-contract-verifier");
+		projectRequest.setBootVersion("2.1.0.RELEASE");
+		assertThat(mavenPom(projectRequest))
+				.hasText("/project/build/plugins/plugin[1]/artifactId", "spring-cloud-contract-maven-plugin")
+				.doesNotContain("testFramework");
+	}
+
+	@Test
+	void springCloudContractVerifierPluginForSpringBoot220WithJUnit5ByDefault() {
+		ProjectRequest projectRequest = createProjectRequest("cloud-contract-verifier");
+		projectRequest.setBootVersion("2.2.0.RELEASE");
+		assertThat(mavenPom(projectRequest))
+				.hasText("/project/build/plugins/plugin[1]/artifactId", "spring-cloud-contract-maven-plugin")
+				.hasText("/project/build/plugins/plugin[1]/configuration/testFramework", "JUNIT5");
 	}
 
 }


### PR DESCRIPTION
Spring Boot 2.2 provides JUnit 5 by default. In order to generate
tests with JUnit 5 the right setup is needed. This commit introduces
the setup for maven and gradle.

See gh-294