### PR TITLE
Upgrade to MyBatis Spring 2.1.1

### DIFF
--- a/start-site/src/main/resources/application.yml
+++ b/start-site/src/main/resources/application.yml
@@ -444,7 +444,7 @@ initializr:
             - compatibilityRange: "[2.0.0.RELEASE,2.1.0.RELEASE)"
               version: 2.0.1
             - compatibilityRange: "2.1.0.RELEASE"
-              version: 2.1.0
+              version: 2.1.1
         - name: Liquibase Migration
           id: liquibase
           description: Liquibase database migration and source control library.


### PR DESCRIPTION
The [mybatis-spring-boot 2.1.1](https://github.com/mybatis/spring-boot-starter/releases/tag/mybatis-spring-boot-2.1.1) has been released at just now. (We tests it using Spring Boot 2.1.9 and 2.2.0 on Travis CI).