### PR TITLE
Upgrade to Apache Camel 3

### DIFF
--- a/start-site/src/main/resources/application.yml
+++ b/start-site/src/main/resources/application.yml
@@ -718,7 +718,7 @@ initializr:
               groupId: org.apache.camel
             - compatibilityRange: "2.2.0.M1"
               version: 3.0.0
-              groupId: org.apache.camel.sprinboot
+              groupId: org.apache.camel.springboot
           description: Apache Camel lets you create the Enterprise Integration Patterns to implement routing and mediation rules a Java based Domain Specific Language via Spring.
           links:
             - rel: reference

--- a/start-site/src/main/resources/application.yml
+++ b/start-site/src/main/resources/application.yml
@@ -712,15 +712,25 @@ initializr:
           mappings:
             - compatibilityRange: "[2.0.0.M1,2.1.0.M1)"
               version: 2.22.4
-            - compatibilityRange: "2.1.0.M1"
+            - compatibilityRange: "[2.1.0.M1,2.2.0.M1)"
               version: 2.24.2
-          description: Apache Camel lets you create the Enterprise Integration Patterns to implement routing and mediation rules a Java based Domain Specific Language via Spring.
+          description: Apache Camel is the Swiss knife of integration.
           groupId: org.apache.camel
           artifactId: camel-spring-boot-starter
           links:
-            - rel: guide
+            - rel: reference
               href: https://camel.apache.org/spring-boot
-              description: Using Apache Camel with Spring Boot
+        - name: Apache Camel
+          id: camel3
+          mappings:
+            - compatibilityRange: "2.2.0.M1"
+              version: 3.0.0
+          description: Apache Camel is the Swiss knife of integration
+          groupId: org.apache.camel.springboot
+          artifactId: camel-spring-boot-starter
+          links:
+            - rel: reference
+              href: https://camel.apache.org/spring-boot
         - name: Solace PubSub+
           id: solace
           compatibilityRange: 2.1.0.RELEASE

--- a/start-site/src/main/resources/application.yml
+++ b/start-site/src/main/resources/application.yml
@@ -708,29 +708,22 @@ initializr:
             - reactive
         - name: Apache Camel
           id: camel
-          compatibilityRange: "[2.0.0.M1,2.2.0.M1)"
+          artifactId: camel-spring-boot-starter
           mappings:
             - compatibilityRange: "[2.0.0.M1,2.1.0.M1)"
               version: 2.22.4
+              groupId: org.apache.camel
             - compatibilityRange: "[2.1.0.M1,2.2.0.M1)"
               version: 2.24.2
-          description: Apache Camel is the Swiss knife of integration.
-          groupId: org.apache.camel
-          artifactId: camel-spring-boot-starter
+              groupId: org.apache.camel
+            - compatibilityRange: "2.2.0.M1"
+              version: 3.0.0
+              groupId: org.apache.camel.sprinboot
+          description: Apache Camel lets you create the Enterprise Integration Patterns to implement routing and mediation rules a Java based Domain Specific Language via Spring.
           links:
             - rel: reference
               href: https://camel.apache.org/spring-boot
         - name: Apache Camel
-          id: camel3
-          mappings:
-            - compatibilityRange: "2.2.0.M1"
-              version: 3.0.0
-          description: Apache Camel is the Swiss knife of integration
-          groupId: org.apache.camel.springboot
-          artifactId: camel-spring-boot-starter
-          links:
-            - rel: reference
-              href: https://camel.apache.org/spring-boot
         - name: Solace PubSub+
           id: solace
           compatibilityRange: 2.1.0.RELEASE


### PR DESCRIPTION
Beware I was not able to test this locally as I get some error about missing fonts.

```
[INFO]  ERROR #11321  PLUGIN
[INFO]
[INFO] "gatsby-plugin-prefetch-google-fonts" threw an error while running the onPreBootstrap lifecycle:
[INFO]
[INFO] ENOENT: no such file or directory, stat '.cache/google-fonts//fonts'
[INFO]

[INFO]
[INFO]   Error: ENOENT: no such file or directory, stat '.cache/google-fonts//fonts'
[INFO]
[INFO] ⠹ onPreBootstrap
[ERROR] error Command failed with exit code 1.
[INFO] info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

So maybe you guys can check this.

In Apache Camel v3 we have changed the groupId for our spring boot starters, from `org.apache.camel` to `org.apache.camel.springboot`. Therefore I created a new `camel3` entry in the yaml file. Not sure if this is the correct way if we want to have support for older Camel 2.x on earlier Spring Boot versions.
