### PR TITLE
Add reactor-kotlin-extensions dependency

### DIFF
--- a/start-site/src/main/java/io/spring/start/site/extension/code/kotlin/KotlinProjectGenerationConfiguration.java
+++ b/start-site/src/main/java/io/spring/start/site/extension/code/kotlin/KotlinProjectGenerationConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 the original author or authors.
+ * Copyright 2012-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,6 +37,7 @@ import org.springframework.context.annotation.Configuration;
  * language.
  *
  * @author Stephane Nicoll
+ * @author Eddú Meléndez
  */
 @ProjectGenerationConfiguration
 @ConditionalOnLanguage(KotlinLanguage.ID)
@@ -69,6 +70,23 @@ class KotlinProjectGenerationConfiguration {
 		@Bean
 		HelpDocumentCustomizer kotlinCoroutinesHelpDocumentCustomizer(Build build) {
 			return (helpDocument) -> this.customizer.customize(helpDocument, build);
+		}
+
+	}
+
+	@Configuration
+	@ConditionalOnPlatformVersion("2.1.0.RELEASE")
+	static class ReactorKotlinExtensionCustomizerConfiguration {
+
+		private final ReactorKotlinExtensionsCustomizer customizer;
+
+		ReactorKotlinExtensionCustomizerConfiguration(InitializrMetadata metadata) {
+			this.customizer = new ReactorKotlinExtensionsCustomizer(metadata);
+		}
+
+		@Bean
+		BuildCustomizer<Build> reactorExtensionsBuildCustomizer() {
+			return this.customizer::customize;
 		}
 
 	}

--- a/start-site/src/main/java/io/spring/start/site/extension/code/kotlin/ReactorKotlinExtensionsCustomizer.java
+++ b/start-site/src/main/java/io/spring/start/site/extension/code/kotlin/ReactorKotlinExtensionsCustomizer.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2012-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.spring.start.site.extension.code.kotlin;
+
+import io.spring.initializr.generator.buildsystem.Build;
+import io.spring.initializr.generator.buildsystem.Dependency;
+import io.spring.initializr.generator.spring.build.BuildCustomizer;
+import io.spring.initializr.generator.spring.build.BuildMetadataResolver;
+import io.spring.initializr.metadata.InitializrMetadata;
+
+/**
+ * A {@link BuildCustomizer} that automatically adds "reactor-kotlin-extensions" when a
+ * dependency with the {@code reactive} facet is selected.
+ *
+ * @author Eddú Meléndez
+ */
+public class ReactorKotlinExtensionsCustomizer {
+
+	private final BuildMetadataResolver buildResolver;
+
+	public ReactorKotlinExtensionsCustomizer(InitializrMetadata metadata) {
+		this.buildResolver = new BuildMetadataResolver(metadata);
+	}
+
+	public void customize(Build build) {
+		if (this.buildResolver.hasFacet(build, "reactive")) {
+			build.dependencies().add("reactor-kotlin-extensions",
+					Dependency.withCoordinates("io.projectreactor.kotlin", "reactor-kotlin-extensions"));
+		}
+	}
+
+}

--- a/start-site/src/test/java/io/spring/start/site/extension/code/kotlin/ReactorKotlinExtensionTests.java
+++ b/start-site/src/test/java/io/spring/start/site/extension/code/kotlin/ReactorKotlinExtensionTests.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2012-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.spring.start.site.extension.code.kotlin;
+
+import io.spring.initializr.generator.test.project.ProjectStructure;
+import io.spring.initializr.web.project.ProjectRequest;
+import io.spring.start.site.extension.AbstractExtensionTests;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link ReactorKotlinExtensionsCustomizer}.
+ *
+ * @author Eddú Meléndez
+ */
+class ReactorKotlinExtensionTests extends AbstractExtensionTests {
+
+	@Test
+	void reactorKotlinExtensionsIsAdded() {
+		ProjectRequest request = createProjectRequest("webflux");
+		request.setBootVersion("2.2.0.M5");
+		request.setLanguage("kotlin");
+		ProjectStructure project = generateProject(request);
+		assertThat(project).mavenBuild().hasDependency("io.projectreactor.kotlin", "reactor-kotlin-extensions");
+	}
+
+	@Test
+	void reactorKotlinExtensionsIsNotAddedWithEarlierVersions() {
+		ProjectRequest request = createProjectRequest("webflux");
+		request.setBootVersion("2.0.0.RELEASE");
+		request.setLanguage("kotlin");
+		assertThat(mavenPom(request)).doesNotHaveDependency("io.projectreactor.kotlin", "reactor-kotlin-extensions");
+	}
+
+	@Test
+	void reactorKotlinExtensionsIsNotAddedWithNonKotlinApp() {
+		ProjectRequest request = createProjectRequest("webflux");
+		request.setBootVersion("2.2.0.M5");
+		request.setLanguage("java");
+		assertThat(mavenPom(request)).doesNotHaveDependency("io.projectreactor.kotlin", "reactor-kotlin-extensions");
+	}
+
+	@Test
+	void reactorKotlinExtensionsIsNotAddedWithoutReactiveFacet() {
+		ProjectRequest request = createProjectRequest("web");
+		request.setBootVersion("2.2.0.M5");
+		request.setLanguage("kotlin");
+		assertThat(mavenPom(request)).doesNotHaveDependency("io.projectreactor.kotlin", "reactor-kotlin-extensions");
+	}
+
+}


### PR DESCRIPTION
When the project has a reactive facet and the language is kotlin the
dependency `reactor-kotlin-entensions` will be added.

See gh-365