### PR TITLE
Upgrade to MyBatis Spring 2.1.2

### DIFF
--- a/start-site/src/main/resources/application.yml
+++ b/start-site/src/main/resources/application.yml
@@ -447,7 +447,7 @@ initializr:
             - compatibilityRange: "[2.0.0.RELEASE,2.1.0.RELEASE)"
               version: 2.0.1
             - compatibilityRange: "2.1.0.RELEASE"
-              version: 2.1.1
+              version: 2.1.2
         - name: Liquibase Migration
           id: liquibase
           description: Liquibase database migration and source control library.


### PR DESCRIPTION
The mybatis-spring-boot 2.1.2 has been released at today. (We tests it using Spring Boot 2.1.13 and 2.2.5 on Travis CI).