### PR TITLE
Add support for Testcontainers

### DIFF
--- a/start-site/src/main/java/io/spring/start/site/extension/dependency/testcontainers/TestcontainersBuildCustomizer.java
+++ b/start-site/src/main/java/io/spring/start/site/extension/dependency/testcontainers/TestcontainersBuildCustomizer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 the original author or authors.
+ * Copyright 2012-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/start-site/src/main/java/io/spring/start/site/extension/dependency/testcontainers/TestcontainersBuildCustomizer.java
+++ b/start-site/src/main/java/io/spring/start/site/extension/dependency/testcontainers/TestcontainersBuildCustomizer.java
@@ -16,8 +16,10 @@
 
 package io.spring.start.site.extension.dependency.testcontainers;
 
-import java.util.HashMap;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import io.spring.initializr.generator.buildsystem.Build;
 import io.spring.initializr.generator.buildsystem.Dependency;
@@ -36,35 +38,40 @@ import io.spring.initializr.metadata.InitializrMetadata;
 public class TestcontainersBuildCustomizer implements BuildCustomizer<Build> {
 
 	/**
-	 * Map from Spring Boot dependency id to Testcontainers artifactId for each supported
-	 * database.
+	 * Supported Testcontainers modules with a mapping to Initializr dependency id.
 	 */
-	private final Map<String, String> driverToTestContainersDependency = new HashMap<>();
+	private final List<TestcontainersModule> supportedModules = Arrays.asList(
+			TestcontainersModule.rdbms("postgresql", "postgresql"), TestcontainersModule.rdbms("mysql", "mysql"),
+			TestcontainersModule.rdbms("mssqlserver", "sqlserver"), TestcontainersModule.rdbms("oracle-xe", "oracle"),
+			TestcontainersModule.noSql("neo4j", "data-neo4j"),
+			TestcontainersModule.noSql("cassandra", "data-cassandra"),
+			TestcontainersModule.noSql("cassandra", "data-cassandra-reactive"),
+			TestcontainersModule.noSql("couchbase", "data-couchbase"),
+			TestcontainersModule.noSql("couchbase", "data-couchbase-reactive"));
 
 	private final InitializrMetadata metadata;
 
 	public TestcontainersBuildCustomizer(InitializrMetadata metadata) {
 		this.metadata = metadata;
-		this.driverToTestContainersDependency.put("postgresql", "postgresql");
-		this.driverToTestContainersDependency.put("mysql", "mysql");
-		this.driverToTestContainersDependency.put("sqlserver", "mssqlserver");
-		this.driverToTestContainersDependency.put("oracle", "oracle-xe");
 	}
 
 	@Override
 	public void customize(Build build) {
 		DependencyContainer dependencies = build.dependencies();
 
-		long includedDrivers = this.driverToTestContainersDependency.entrySet().stream()
-				.filter((entry) -> dependencies.has(entry.getKey()))
-				.peek((entry) -> addTestcontainersDriverDependency(dependencies, entry.getValue())).count();
+		Map<Type, Long> addedDependencies = this.supportedModules.stream()
+				.filter((module) -> dependencies.has(module.getInitializrDependencyName()))
+				.peek((module) -> addTestcontainersDriverDependency(dependencies, module.getName()))
+				.collect(Collectors.groupingBy(TestcontainersModule::getType, Collectors.counting()));
 
-		if (includedDrivers > 0) {
-			removeTestcontainers(build);
-
+		if (addedDependencies.containsKey(Type.RDBMS) && addedDependencies.get(Type.RDBMS) > 0) {
 			if (dependencies.has("data-r2dbc")) {
 				addTestcontainersDriverDependency(dependencies, "r2dbc");
 			}
+		}
+
+		if (!addedDependencies.isEmpty()) {
+			this.removeTestcontainers(build);
 		}
 	}
 
@@ -87,6 +94,48 @@ public class TestcontainersBuildCustomizer implements BuildCustomizer<Build> {
 		}
 		build.boms().add(testcontainers.getBom());
 		build.dependencies().remove("testcontainers");
+	}
+
+	private static final class TestcontainersModule {
+
+		private final String name;
+
+		private final String initializrDependencyName;
+
+		private final Type type;
+
+		static TestcontainersModule rdbms(String name, String initializrDependencyName) {
+			return new TestcontainersModule(name, initializrDependencyName, Type.RDBMS);
+		}
+
+		static TestcontainersModule noSql(String name, String initializrDependencyName) {
+			return new TestcontainersModule(name, initializrDependencyName, Type.NO_SQL);
+		}
+
+		private TestcontainersModule(String name, String initializrDependencyName, Type type) {
+			this.name = name;
+			this.initializrDependencyName = initializrDependencyName;
+			this.type = type;
+		}
+
+		String getName() {
+			return this.name;
+		}
+
+		String getInitializrDependencyName() {
+			return this.initializrDependencyName;
+		}
+
+		Type getType() {
+			return this.type;
+		}
+
+	}
+
+	private enum Type {
+
+		RDBMS, NO_SQL;
+
 	}
 
 }

--- a/start-site/src/main/java/io/spring/start/site/extension/dependency/testcontainers/TestcontainersBuildCustomizer.java
+++ b/start-site/src/main/java/io/spring/start/site/extension/dependency/testcontainers/TestcontainersBuildCustomizer.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2012-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.spring.start.site.extension.dependency.testcontainers;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import io.spring.initializr.generator.buildsystem.Build;
+import io.spring.initializr.generator.buildsystem.Dependency;
+import io.spring.initializr.generator.buildsystem.DependencyContainer;
+import io.spring.initializr.generator.buildsystem.DependencyScope;
+import io.spring.initializr.generator.spring.build.BuildCustomizer;
+import io.spring.initializr.metadata.BillOfMaterials;
+import io.spring.initializr.metadata.InitializrMetadata;
+
+/**
+ * {@link BuildCustomizer} for Testcontainers that adds Testcontainers database specific
+ * modules if database drivers are added as dependency.
+ *
+ * @author Maciej Walkowiak
+ */
+public class TestcontainersBuildCustomizer implements BuildCustomizer<Build> {
+
+	/**
+	 * Map from Spring Boot dependency id to Testcontainers artifactId for each supported
+	 * database.
+	 */
+	private final Map<String, String> driverToTestContainersDependency = new HashMap<>();
+
+	private final InitializrMetadata metadata;
+
+	public TestcontainersBuildCustomizer(InitializrMetadata metadata) {
+		this.metadata = metadata;
+		this.driverToTestContainersDependency.put("postgresql", "postgresql");
+		this.driverToTestContainersDependency.put("mysql", "mysql");
+		this.driverToTestContainersDependency.put("sqlserver", "mssqlserver");
+		this.driverToTestContainersDependency.put("oracle", "oracle-xe");
+	}
+
+	@Override
+	public void customize(Build build) {
+		DependencyContainer dependencies = build.dependencies();
+
+		long includedDrivers = this.driverToTestContainersDependency.entrySet().stream()
+				.filter((entry) -> dependencies.has(entry.getKey()))
+				.peek((entry) -> addTestcontainersDriverDependency(dependencies, entry.getValue())).count();
+
+		if (includedDrivers > 0) {
+			removeTestcontainers(build);
+
+			if (dependencies.has("data-r2dbc")) {
+				addTestcontainersDriverDependency(dependencies, "r2dbc");
+			}
+		}
+	}
+
+	private void addTestcontainersDriverDependency(DependencyContainer dependencies, String testcontainersArtifactId) {
+		dependencies.add("testcontainers-" + testcontainersArtifactId,
+				Dependency.withCoordinates("org.testcontainers", testcontainersArtifactId)
+						.scope(DependencyScope.TEST_COMPILE).build());
+	}
+
+	/**
+	 * Removes Testcontainers core dependency which is not needed as it is a transient
+	 * dependency for database specific Testcontainers modules.
+	 * @param build - build configuration for the project
+	 */
+	private void removeTestcontainers(Build build) {
+		io.spring.initializr.metadata.Dependency testcontainers = this.metadata.getDependencies().get("testcontainers");
+		BillOfMaterials bom = this.metadata.getConfiguration().getEnv().getBoms().get(testcontainers.getBom());
+		if (bom.getVersionProperty() != null) {
+			build.properties().version(bom.getVersionProperty(), bom.getVersion());
+		}
+		build.boms().add(testcontainers.getBom());
+		build.dependencies().remove("testcontainers");
+	}
+
+}

--- a/start-site/src/main/java/io/spring/start/site/extension/dependency/testcontainers/TestcontainersHelpCustomizer.java
+++ b/start-site/src/main/java/io/spring/start/site/extension/dependency/testcontainers/TestcontainersHelpCustomizer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 the original author or authors.
+ * Copyright 2012-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/start-site/src/main/java/io/spring/start/site/extension/dependency/testcontainers/TestcontainersHelpCustomizer.java
+++ b/start-site/src/main/java/io/spring/start/site/extension/dependency/testcontainers/TestcontainersHelpCustomizer.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2012-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.spring.start.site.extension.dependency.testcontainers;
+
+import java.util.Arrays;
+import java.util.List;
+
+import io.spring.initializr.generator.buildsystem.Build;
+import io.spring.initializr.generator.spring.documentation.HelpDocument;
+import io.spring.initializr.generator.spring.documentation.HelpDocumentCustomizer;
+
+/**
+ * A {@link HelpDocumentCustomizer} that adds a reference links when Testcontainers and
+ * one of JDBC or R2DBC drivers is selected.
+ *
+ * @author Maciej Walkowiak
+ */
+public class TestcontainersHelpCustomizer implements HelpDocumentCustomizer {
+
+	private static final List<String> DRIVERS = Arrays.asList("mysql", "postgresql", "sqlserver", "oracle");
+
+	private final Build build;
+
+	public TestcontainersHelpCustomizer(Build build) {
+		this.build = build;
+	}
+
+	@Override
+	public void customize(HelpDocument document) {
+		if (this.build.dependencies().ids().anyMatch(DRIVERS::contains)) {
+			if (this.build.dependencies().has("data-r2dbc")) {
+				document.gettingStarted().addReferenceDocLink("https://www.testcontainers.org/modules/databases/r2dbc/",
+						"Testcontainers R2DBC support reference");
+			}
+			else {
+				document.gettingStarted().addReferenceDocLink("https://www.testcontainers.org/modules/databases/jdbc/",
+						"Testcontainers JDBC support reference");
+			}
+		}
+	}
+
+}

--- a/start-site/src/main/java/io/spring/start/site/extension/dependency/testcontainers/TestcontainersHelpCustomizer.java
+++ b/start-site/src/main/java/io/spring/start/site/extension/dependency/testcontainers/TestcontainersHelpCustomizer.java
@@ -25,7 +25,7 @@ import io.spring.initializr.generator.spring.documentation.HelpDocumentCustomize
 
 /**
  * A {@link HelpDocumentCustomizer} that adds a reference links when Testcontainers and
- * one of JDBC or R2DBC drivers is selected.
+ * one of supported NoSQL databases, JDBC or R2DBC drivers is selected.
  *
  * @author Maciej Walkowiak
  */
@@ -50,6 +50,23 @@ public class TestcontainersHelpCustomizer implements HelpDocumentCustomizer {
 				document.gettingStarted().addReferenceDocLink("https://www.testcontainers.org/modules/databases/jdbc/",
 						"Testcontainers JDBC support reference");
 			}
+		}
+
+		if (this.build.dependencies().has("data-neo4j")) {
+			document.gettingStarted().addReferenceDocLink("https://www.testcontainers.org/modules/databases/neo4j/",
+					"Testcontainers Neo4j support reference");
+		}
+
+		if (this.build.dependencies().has("data-cassandra")
+				|| this.build.dependencies().has("data-cassandra-reactive")) {
+			document.gettingStarted().addReferenceDocLink("https://www.testcontainers.org/modules/databases/cassandra/",
+					"Testcontainers Cassandra support reference");
+		}
+
+		if (this.build.dependencies().has("data-couchbase")
+				|| this.build.dependencies().has("data-couchbase-reactive")) {
+			document.gettingStarted().addReferenceDocLink("https://www.testcontainers.org/modules/databases/couchbase/",
+					"Testcontainers Couchbase support reference");
 		}
 	}
 

--- a/start-site/src/main/java/io/spring/start/site/extension/dependency/testcontainers/TestcontainersProjectGenerationConfiguration.java
+++ b/start-site/src/main/java/io/spring/start/site/extension/dependency/testcontainers/TestcontainersProjectGenerationConfiguration.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2012-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.spring.start.site.extension.dependency.testcontainers;
+
+import io.spring.initializr.generator.buildsystem.Build;
+import io.spring.initializr.generator.condition.ConditionalOnRequestedDependency;
+import io.spring.initializr.generator.project.ProjectGenerationConfiguration;
+import io.spring.initializr.metadata.InitializrMetadata;
+
+import org.springframework.context.annotation.Bean;
+
+/**
+ * Configuration for generation of projects that depend on Testcontainers.
+ *
+ * @author Maciej Walkowiak
+ */
+@ProjectGenerationConfiguration
+public class TestcontainersProjectGenerationConfiguration {
+
+	@Bean
+	@ConditionalOnRequestedDependency("testcontainers")
+	public TestcontainersBuildCustomizer testContainersBuildCustomizer(InitializrMetadata metadata) {
+		return new TestcontainersBuildCustomizer(metadata);
+	}
+
+	@Bean
+	@ConditionalOnRequestedDependency("testcontainers")
+	public TestcontainersHelpCustomizer testcontainersHelpCustomizer(Build build) {
+		return new TestcontainersHelpCustomizer(build);
+	}
+
+}

--- a/start-site/src/main/java/io/spring/start/site/extension/dependency/testcontainers/package-info.java
+++ b/start-site/src/main/java/io/spring/start/site/extension/dependency/testcontainers/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 the original author or authors.
+ * Copyright 2012-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/start-site/src/main/java/io/spring/start/site/extension/dependency/testcontainers/package-info.java
+++ b/start-site/src/main/java/io/spring/start/site/extension/dependency/testcontainers/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2012-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Extensions for generation of projects that depend on Testcontainers.
+ */
+package io.spring.start.site.extension.dependency.testcontainers;

--- a/start-site/src/main/resources/META-INF/spring.factories
+++ b/start-site/src/main/resources/META-INF/spring.factories
@@ -10,5 +10,6 @@ io.spring.start.site.extension.dependency.springcloud.SpringCloudProjectGenerati
 io.spring.start.site.extension.dependency.springdata.SpringDataProjectGenerationConfiguration,\
 io.spring.start.site.extension.dependency.springintegration.SpringIntegrationProjectGenerationConfiguration,\
 io.spring.start.site.extension.dependency.springrestdocs.SpringRestDocsProjectGenerationConfiguration,\
+io.spring.start.site.extension.dependency.testcontainers.TestcontainersProjectGenerationConfiguration,\
 io.spring.start.site.extension.description.DescriptionProjectGenerationConfiguration,\
 io.spring.start.site.extension.code.kotlin.KotlinProjectGenerationConfiguration

--- a/start-site/src/main/resources/application.yml
+++ b/start-site/src/main/resources/application.yml
@@ -163,6 +163,11 @@ initializr:
           - compatibilityRange: "2.3.x.BUILD-SNAPSHOT"
             version: 2.0.0-SNAPSHOT
             repositories: spring-snapshots
+      testcontainers:
+        groupId: org.testcontainers
+        artifactId: testcontainers-bom
+        version: 1.14.1
+        versionProperty: testcontainers.version
     gradle:
       dependency-management-plugin-version: 1.0.9.RELEASE
     kotlin:
@@ -946,6 +951,18 @@ initializr:
           artifactId: de.flapdoodle.embed.mongo
           scope: test
           starter: false
+        - name: Testcontainers
+          id: testcontainers
+          description: Java library that supports JUnit tests, providing lightweight, throwaway instances of common databases, Selenium web browsers, or anything else that can run in a Docker container.
+          groupId: org.testcontainers
+          artifactId: testcontainers
+          bom: testcontainers
+          scope: test
+          starter: false
+          links:
+            - rel: reference
+              href: https://www.testcontainers.org/
+              description: Testcontainers official documentation
     - name: Spring Cloud
       bom: spring-cloud
       content:

--- a/start-site/src/test/java/io/spring/start/site/extension/dependency/testcontainers/TestcontainersBuildCustomizerTests.java
+++ b/start-site/src/test/java/io/spring/start/site/extension/dependency/testcontainers/TestcontainersBuildCustomizerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 the original author or authors.
+ * Copyright 2012-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/start-site/src/test/java/io/spring/start/site/extension/dependency/testcontainers/TestcontainersBuildCustomizerTests.java
+++ b/start-site/src/test/java/io/spring/start/site/extension/dependency/testcontainers/TestcontainersBuildCustomizerTests.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2012-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.spring.start.site.extension.dependency.testcontainers;
+
+import io.spring.initializr.generator.test.project.ProjectStructure;
+import io.spring.initializr.metadata.Dependency;
+import io.spring.initializr.web.project.ProjectRequest;
+import io.spring.start.site.extension.AbstractExtensionTests;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link TestcontainersBuildCustomizer}.
+ *
+ * @author Maciej Walkowiak
+ */
+class TestcontainersBuildCustomizerTests extends AbstractExtensionTests {
+
+	@Test
+	void onlyTestContainersWithoutDrivers() {
+		assertThat(generateProject("testcontainers")).mavenBuild()
+				.hasBom("org.testcontainers", "testcontainers-bom", "${testcontainers.version}")
+				.hasDependency(getDependency("testcontainers"));
+	}
+
+	@ParameterizedTest
+	@CsvSource({ "postgresql,postgresql", "mysql,mysql", "sqlserver,mssqlserver", "oracle,oracle-xe" })
+	void testcontainersWithJdbcDatabaseDriver(String springBootDependencyId, String testcontainersArtifactId) {
+		Dependency testcontainers = getDependency("testcontainers");
+
+		assertThat(generateProject("testcontainers", springBootDependencyId)).mavenBuild()
+				.hasBom("org.testcontainers", "testcontainers-bom", "${testcontainers.version}")
+				.hasDependency(getDependency(springBootDependencyId))
+				.hasDependency("org.testcontainers", testcontainersArtifactId, null, "test")
+				.doesNotHaveDependency(testcontainers.getGroupId(), testcontainers.getArtifactId())
+				.doesNotHaveDependency("org.testcontainers", "r2dbc");
+	}
+
+	@ParameterizedTest
+	@CsvSource({ "postgresql,postgresql", "mysql,mysql", "sqlserver,mssqlserver", "oracle,oracle-xe" })
+	void testcontainersWithR2dbcDatabaseDriver(String springBootDependencyId, String testcontainersArtifactId) {
+		Dependency testcontainers = getDependency("testcontainers");
+
+		assertThat(generateProject("testcontainers", "data-r2dbc", springBootDependencyId)).mavenBuild()
+				.hasBom("org.testcontainers", "testcontainers-bom", "${testcontainers.version}")
+				.hasDependency(getDependency(springBootDependencyId))
+				.hasDependency("org.testcontainers", "r2dbc", null, "test")
+				.hasDependency("org.testcontainers", testcontainersArtifactId, null, "test")
+				.doesNotHaveDependency(testcontainers.getGroupId(), testcontainers.getArtifactId());
+	}
+
+	@Test
+	void testcontainersWithR2dbcNoDatabaseDriver() {
+		Dependency testcontainers = getDependency("testcontainers");
+
+		assertThat(generateProject("testcontainers", "data-r2dbc")).mavenBuild()
+				.hasBom("org.testcontainers", "testcontainers-bom", "${testcontainers.version}")
+				.hasDependency(getDependency("testcontainers")).doesNotHaveDependency("org.testcontainers", "r2dbc");
+	}
+
+	private ProjectStructure generateProject(String... dependencies) {
+		ProjectRequest request = createProjectRequest(dependencies);
+		request.setBootVersion("2.3.0.BUILD-SNAPSHOT");
+		request.setType("maven-build");
+		return generateProject(request);
+	}
+
+}

--- a/start-site/src/test/java/io/spring/start/site/extension/dependency/testcontainers/TestcontainersHelpCustomizerTest.java
+++ b/start-site/src/test/java/io/spring/start/site/extension/dependency/testcontainers/TestcontainersHelpCustomizerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 the original author or authors.
+ * Copyright 2012-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/start-site/src/test/java/io/spring/start/site/extension/dependency/testcontainers/TestcontainersHelpCustomizerTest.java
+++ b/start-site/src/test/java/io/spring/start/site/extension/dependency/testcontainers/TestcontainersHelpCustomizerTest.java
@@ -36,7 +36,7 @@ class TestcontainersHelpCustomizerTest {
 
 	@ParameterizedTest
 	@ValueSource(strings = { "postgresql", "mysql", "sqlserver", "oracle" })
-	void jdbcWithNoMatchingDriver(String driver) {
+	void addsLinkToJdbcModuleWhenR2dbcIsNotPresent(String driver) {
 		HelpDocument helpDocument = createHelpDocument("testcontainers", driver);
 		assertThat(helpDocument.gettingStarted().referenceDocs().getItems()).hasSize(1);
 		assertThat(helpDocument.gettingStarted().referenceDocs().getItems().get(0).getHref())
@@ -45,7 +45,7 @@ class TestcontainersHelpCustomizerTest {
 
 	@ParameterizedTest
 	@ValueSource(strings = { "postgresql", "mysql", "sqlserver", "oracle" })
-	void r2dbcWithNoMatchingDriver(String driver) {
+	void addsLinkToR2dbcModuleWhenR2dbcIsPresent(String driver) {
 		HelpDocument helpDocument = createHelpDocument("testcontainers", "data-r2dbc", driver);
 		assertThat(helpDocument.gettingStarted().referenceDocs().getItems()).hasSize(1);
 		assertThat(helpDocument.gettingStarted().referenceDocs().getItems().get(0).getHref())

--- a/start-site/src/test/java/io/spring/start/site/extension/dependency/testcontainers/TestcontainersHelpCustomizerTest.java
+++ b/start-site/src/test/java/io/spring/start/site/extension/dependency/testcontainers/TestcontainersHelpCustomizerTest.java
@@ -22,6 +22,7 @@ import io.spring.initializr.generator.buildsystem.gradle.GradleBuild;
 import io.spring.initializr.generator.io.template.MustacheTemplateRenderer;
 import io.spring.initializr.generator.spring.documentation.HelpDocument;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -50,6 +51,16 @@ class TestcontainersHelpCustomizerTest {
 		assertThat(helpDocument.gettingStarted().referenceDocs().getItems()).hasSize(1);
 		assertThat(helpDocument.gettingStarted().referenceDocs().getItems().get(0).getHref())
 				.isEqualTo("https://www.testcontainers.org/modules/databases/r2dbc/");
+	}
+
+	@ParameterizedTest
+	@CsvSource({ "data-neo4j,neo4j", "data-cassandra,cassandra", "data-cassandra-reactive,cassandra",
+			"data-couchbase,couchbase", "data-couchbase-reactive,couchbase" })
+	void addsLinkToNoSQlModule(String noSqlModule, String testcontainersModule) {
+		HelpDocument helpDocument = createHelpDocument("testcontainers", noSqlModule);
+		assertThat(helpDocument.gettingStarted().referenceDocs().getItems()).hasSize(1);
+		assertThat(helpDocument.gettingStarted().referenceDocs().getItems().get(0).getHref())
+				.isEqualTo("https://www.testcontainers.org/modules/databases/" + testcontainersModule + "/");
 	}
 
 	private HelpDocument createHelpDocument(String... dependencyIds) {

--- a/start-site/src/test/java/io/spring/start/site/extension/dependency/testcontainers/TestcontainersHelpCustomizerTest.java
+++ b/start-site/src/test/java/io/spring/start/site/extension/dependency/testcontainers/TestcontainersHelpCustomizerTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2012-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.spring.start.site.extension.dependency.testcontainers;
+
+import io.spring.initializr.generator.buildsystem.Build;
+import io.spring.initializr.generator.buildsystem.Dependency;
+import io.spring.initializr.generator.buildsystem.gradle.GradleBuild;
+import io.spring.initializr.generator.io.template.MustacheTemplateRenderer;
+import io.spring.initializr.generator.spring.documentation.HelpDocument;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+/**
+ * Tests for {@link TestcontainersHelpCustomizer}.
+ *
+ * @author Maciej Walkowiak
+ */
+class TestcontainersHelpCustomizerTest {
+
+	@ParameterizedTest
+	@ValueSource(strings = { "postgresql", "mysql", "sqlserver", "oracle" })
+	void jdbcWithNoMatchingDriver(String driver) {
+		HelpDocument helpDocument = createHelpDocument("testcontainers", driver);
+		assertThat(helpDocument.gettingStarted().referenceDocs().getItems()).hasSize(1);
+		assertThat(helpDocument.gettingStarted().referenceDocs().getItems().get(0).getHref())
+				.isEqualTo("https://www.testcontainers.org/modules/databases/jdbc/");
+	}
+
+	@ParameterizedTest
+	@ValueSource(strings = { "postgresql", "mysql", "sqlserver", "oracle" })
+	void r2dbcWithNoMatchingDriver(String driver) {
+		HelpDocument helpDocument = createHelpDocument("testcontainers", "data-r2dbc", driver);
+		assertThat(helpDocument.gettingStarted().referenceDocs().getItems()).hasSize(1);
+		assertThat(helpDocument.gettingStarted().referenceDocs().getItems().get(0).getHref())
+				.isEqualTo("https://www.testcontainers.org/modules/databases/r2dbc/");
+	}
+
+	private HelpDocument createHelpDocument(String... dependencyIds) {
+		Build build = new GradleBuild();
+		for (String dependencyId : dependencyIds) {
+			build.dependencies().add(dependencyId, Dependency.withCoordinates(dependencyId, dependencyId));
+		}
+		HelpDocument document = new HelpDocument(mock(MustacheTemplateRenderer.class));
+		new TestcontainersHelpCustomizer(build).customize(document);
+		return document;
+	}
+
+}


### PR DESCRIPTION
When Testcontainers is chosen along with any of supported JDBC drivers it will add dependency to Testcontainers database module related to selected JDBC driver.

When Testcontainers is chosen along with R2DBC driver and Spring Data R2DBC it will add extra dependency to Testcontainers R2DBC module.

Relevant links to Testcontainers documentation are added to `HELP.md` file.