### PR TITLE
Relative links in index.html to assets for production build

### DIFF
--- a/start-client/webpack.prod.js
+++ b/start-client/webpack.prod.js
@@ -18,6 +18,9 @@ const config = {
       chunks: 'all',
     },
   },
+  output: {
+    publicPath: './',
+  },
   plugins: [
     new BundleAnalyzerPlugin({
       analyzerMode: 'static',


### PR DESCRIPTION
Another try at switching absolute asset links to relative. Only for production build this time