### PR TITLE
Upgrade to MyBatis Spring 2.1.3

### DIFF
--- a/start-site/src/main/resources/application.yml
+++ b/start-site/src/main/resources/application.yml
@@ -467,7 +467,7 @@ initializr:
             - compatibilityRange: "[2.0.0.RELEASE,2.1.0.RELEASE)"
               version: 2.0.1
             - compatibilityRange: "2.1.0.RELEASE"
-              version: 2.1.2
+              version: 2.1.3
         - name: Liquibase Migration
           id: liquibase
           description: Liquibase database migration and source control library.


### PR DESCRIPTION
The mybatis-spring-boot 2.1.3(switch baseline to spring-boot 2.3.x) has been released at today. (We tests it using Spring Boot 2.1.x, 2.2.x and 2.3.x on Travis CI).