### PR TITLE
Enable GCP support with Spring Boot 2.3.x

### DIFF
--- a/start-site/src/main/resources/application.yml
+++ b/start-site/src/main/resources/application.yml
@@ -1310,7 +1310,7 @@ initializr:
               href: https://github.com/Microsoft/azure-spring-boot/tree/master/azure-spring-boot-starters/azure-storage-spring-boot-starter
     - name: Google Cloud Platform
       bom: spring-cloud
-      compatibilityRange: "[2.0.0.RELEASE,2.3.0.M1)"
+      compatibilityRange: "[2.0.0.RELEASE,2.4.0-M1)"
       content:
         - name: GCP Support
           id: cloud-gcp


### PR DESCRIPTION
Updates the compatibility range for GCP libraries in initializr; it is usable in the new versions of spring boot as well.

cc/ @meltsufin