### PR TITLE
Add Neo4j Bolt driver option.

### DIFF
--- a/start-client/dev/api.json
+++ b/start-client/dev/api.json
@@ -646,6 +646,11 @@
                 "templated": true
               }
             }
+          },
+          {
+            "id": "neo4j",
+            "name": "Neo4j Bolt driver",
+            "description": "A Neo4j Java driver that connects to a Neo4j instance or cluster using the Bolt protocol."
           }
         ]
       },

--- a/start-site/src/main/resources/application.yml
+++ b/start-site/src/main/resources/application.yml
@@ -666,6 +666,12 @@ initializr:
               description: Accessing Data with Neo4j
             - rel: reference
               href: https://docs.spring.io/spring-boot/docs/{bootVersion}/reference/htmlsingle/#boot-features-neo4j
+        - name: Neo4j Bolt driver
+          id: neo4j
+          description: A Neo4j Java driver that connects to a Neo4j instance or cluster using the Bolt protocol.
+          groupId: org.neo4j.driver
+          artifactId: neo4j-java-driver
+          starter: false
     - name: Messaging
       content:
         - name: Spring Integration


### PR DESCRIPTION
As a completion (or sidekick) for the changes in https://github.com/spring-projects/spring-boot/pull/22299 we would purpose to bring direct access to the Neo4j Java driver into the initializer.
This aligns with the already existing PostgreSQL, Oracle, etc. support and is a hugely demanded feature we hear from our community and customers. The background is that those users do not want to have to opt-in for a Spring Data (Neo4j) to just get a managed driver bean.

Looking forward to your feedback.

(ps: I love the easiness of adding configuration options in the initializer project 👍 )