### PR TITLE
Fixing issue #522 - instance of ProjectGenerationInvoker is created per test method

### DIFF
--- a/start-site/src/test/java/io/spring/start/site/ProjectGenerationIntegrationTests.java
+++ b/start-site/src/test/java/io/spring/start/site/ProjectGenerationIntegrationTests.java
@@ -99,14 +99,13 @@ class ProjectGenerationIntegrationTests {
 		}
 	});
 
-	private final ProjectGenerationInvoker<ProjectRequest> invoker;
+	private final ApplicationContext applicationContext;
 
 	private final InitializrMetadata metadata;
 
 	ProjectGenerationIntegrationTests(@Autowired ApplicationContext applicationContext,
 			@Autowired InitializrMetadataProvider metadataProvider) {
-		this.invoker = new ProjectGenerationInvoker<>(applicationContext,
-				new DefaultProjectRequestToDescriptionConverter());
+		this.applicationContext = applicationContext;
 		this.metadata = metadataProvider.get();
 	}
 
@@ -167,7 +166,9 @@ class ProjectGenerationIntegrationTests {
 		request.setArtifactId("demo");
 		request.setApplicationName("DemoApplication");
 		request.setDependencies(Arrays.asList("devtools", "configuration-processor"));
-		Path project = this.invoker.invokeProjectStructureGeneration(request).getRootDirectory();
+		ProjectGenerationInvoker<ProjectRequest> invoker = new ProjectGenerationInvoker<>(this.applicationContext,
+				new DefaultProjectRequestToDescriptionConverter());
+		Path project = invoker.invokeProjectStructureGeneration(request).getRootDirectory();
 		ProcessBuilder processBuilder = createProcessBuilder(buildSystem);
 		processBuilder.directory(project.toFile());
 		Path output = Files.createTempFile(directory, "output-", ".log");


### PR DESCRIPTION
This pull request fixes #522 . The instance of `ProjectGenerationInvoker` is created per method invocation to get rid of `ConcurrentModificationException` because `ProjectGenerationInvoker` is not thread safe as it uses `LinkedHashMap` internally without any synchornization.