### PR TITLE
Upgrade to MyBatis Spring Boot 2.1.4

### DIFF
--- a/start-site/src/main/resources/application.yml
+++ b/start-site/src/main/resources/application.yml
@@ -498,7 +498,7 @@ initializr:
               description: R2DBC Homepage
         - name: MyBatis Framework
           id: mybatis
-          compatibilityRange: "[2.0.0.RELEASE,2.4.0-M1)"
+          compatibilityRange: "2.0.0.RELEASE"
           description: Persistence framework with support for custom SQL, stored procedures and advanced mappings. MyBatis couples objects with stored procedures or SQL statements using a XML descriptor or annotations.
           links:
             - rel: guide
@@ -511,8 +511,8 @@ initializr:
           mappings:
             - compatibilityRange: "[2.0.0.RELEASE,2.1.0.RELEASE)"
               version: 2.0.1
-            - compatibilityRange: "[2.1.0.RELEASE,2.4.0-M1)"
-              version: 2.1.3
+            - compatibilityRange: "2.1.0.RELEASE"
+              version: 2.1.4
         - name: Liquibase Migration
           id: liquibase
           description: Liquibase database migration and source control library.


### PR DESCRIPTION
The mybatis-spring-boot 2.1.4(switch baseline to spring-boot 2.4.x) has been released at today. (We tests it using Spring Boot 2.1.x, 2.2.x, 2.3.x and 2.4.x on Travis CI).

* https://github.com/mybatis/spring-boot-starter/releases/tag/mybatis-spring-boot-2.1.4