### PR TITLE
Update compatibility range for 'okta'

### DIFF
--- a/start-site/src/main/resources/application.yml
+++ b/start-site/src/main/resources/application.yml
@@ -429,14 +429,12 @@ initializr:
           description: Okta specific configuration for Spring Security/Spring Boot OAuth2 features. Enable your Spring Boot application to work with Okta via OAuth 2.0/OIDC.
           groupId: com.okta.spring
           artifactId: okta-spring-boot-starter
-          compatibilityRange: "[2.1.2.RELEASE,2.4.0-M1)"
+          compatibilityRange: "2.4.0"
           mappings:
             - compatibilityRange: "[2.1.2.RELEASE,2.2.0.M1)"
               version: 1.2.1
             - compatibilityRange: "[2.2.0.M1,2.4.0-M1)"
               version: 1.4.0
-            - compatibilityRange: "[2.4.0,)"
-              version: 1.5.0
           links:
             - rel: guide
               href: https://github.com/okta/samples-java-spring/tree/master/okta-hosted-login

--- a/start-site/src/main/resources/application.yml
+++ b/start-site/src/main/resources/application.yml
@@ -435,6 +435,8 @@ initializr:
               version: 1.2.1
             - compatibilityRange: "[2.2.0.M1,2.4.0-M1)"
               version: 1.4.0
+            - compatibilityRange: "[2.4.0,)"
+              version: 1.5.0
           links:
             - rel: guide
               href: https://github.com/okta/samples-java-spring/tree/master/okta-hosted-login


### PR DESCRIPTION
The Okta Spring Boot Starter v1.5.0 has a minimum version compatibility with Boot 2.4