### PR TITLE
Fix validation entry description to refer to Bean Validation API

### DIFF
--- a/start-site/src/main/resources/application.yml
+++ b/start-site/src/main/resources/application.yml
@@ -859,7 +859,7 @@ initializr:
               href: https://docs.spring.io/spring-boot/docs/{bootVersion}/reference/htmlsingle/#howto-batch-applications
         - name: Validation
           id: validation
-          description: JSR-303 validation with Hibernate validator.
+          description: JSR-380 validation with Hibernate validator.
           links:
             - rel: reference
               href: https://docs.spring.io/spring-boot/docs/{bootVersion}/reference/htmlsingle/#boot-features-validation


### PR DESCRIPTION
The Validation Spec description not JSR-303 but JSR-380.
So I updated description JSR-303 to JSR-380.

I was confused about this description. 'JSR-303 validation with Hibernate validator.'
Spring Boot Starter Validation is using jakarta bean validation 2.0(JSR-380).
So, I think this description could be changed.

Thank you for this project!