### PR TITLE
Include Spring Integration specific modules when a matching entry is selected

### DIFF
--- a/start-site/src/main/java/io/spring/start/site/extension/dependency/springintegration/SpringIntegrationBuildCustomizer.java
+++ b/start-site/src/main/java/io/spring/start/site/extension/dependency/springintegration/SpringIntegrationBuildCustomizer.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2012-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.spring.start.site.extension.dependency.springintegration;
+
+import io.spring.initializr.generator.buildsystem.Build;
+import io.spring.initializr.generator.spring.build.BuildCustomizer;
+
+/**
+ * {@link BuildCustomizer} for Spring Integration that adds a specific module if a
+ * supported entry is selected.
+ *
+ * @author Artem Bilan
+ * @author Stephane Nicoll
+ */
+class SpringIntegrationBuildCustomizer implements BuildCustomizer<Build> {
+
+	private final SpringIntegrationModuleRegistry modulesRegistry;
+
+	SpringIntegrationBuildCustomizer(SpringIntegrationModuleRegistry modulesRegistry) {
+		this.modulesRegistry = modulesRegistry;
+	}
+
+	@Override
+	public void customize(Build build) {
+		this.modulesRegistry.modules().forEach((module) -> module.customize(build));
+	}
+
+}

--- a/start-site/src/main/java/io/spring/start/site/extension/dependency/springintegration/SpringIntegrationHelpCustomizer.java
+++ b/start-site/src/main/java/io/spring/start/site/extension/dependency/springintegration/SpringIntegrationHelpCustomizer.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2012-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.spring.start.site.extension.dependency.springintegration;
+
+import io.spring.initializr.generator.buildsystem.Build;
+import io.spring.initializr.generator.spring.documentation.HelpDocument;
+import io.spring.initializr.generator.spring.documentation.HelpDocumentCustomizer;
+
+/**
+ * A {@link HelpDocumentCustomizer} that adds a reference link for each supported
+ * Spring Integration entry when Spring Integration is selected.
+ *
+ * @author Artem Bilan
+ * @author Stephane Nicoll
+ */
+class SpringIntegrationHelpCustomizer implements HelpDocumentCustomizer {
+
+	private final SpringIntegrationModuleRegistry modulesRegistry;
+
+	private final Build build;
+
+	SpringIntegrationHelpCustomizer(SpringIntegrationModuleRegistry modulesRegistry, Build build) {
+		this.modulesRegistry = modulesRegistry;
+		this.build = build;
+	}
+
+	@Override
+	public void customize(HelpDocument document) {
+		this.modulesRegistry.modules()
+				.filter((module) -> module.match(this.build))
+				.forEach((module) ->
+						document.gettingStarted()
+								.addReferenceDocLink(module.getDocumentationUrl(),
+										String.format("Spring Integration %s Reference Guide", module.getName())));
+	}
+
+}

--- a/start-site/src/main/java/io/spring/start/site/extension/dependency/springintegration/SpringIntegrationModule.java
+++ b/start-site/src/main/java/io/spring/start/site/extension/dependency/springintegration/SpringIntegrationModule.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2012-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.spring.start.site.extension.dependency.springintegration;
+
+import java.util.function.Consumer;
+
+import io.spring.initializr.generator.buildsystem.Build;
+
+/**
+ * Represent a Spring Integration module and how it should affect a generated project that
+ * matches a configurable set of entries.
+ *
+ * @author Artem Bilan
+ * @author Stephane Nicoll
+ */
+class SpringIntegrationModule {
+
+	private final String name;
+
+	private final String documentationUrl;
+
+	private final String[] triggeredDependencyIds;
+
+	private final Consumer<Build> buildCustomizer;
+
+	SpringIntegrationModule(String name, String documentationUrl, Consumer<Build> buildCustomizer,
+			String... triggeredDependencyIds) {
+
+		this.name = name;
+		this.documentationUrl = documentationUrl;
+		this.triggeredDependencyIds = triggeredDependencyIds;
+		this.buildCustomizer = buildCustomizer;
+	}
+
+	String getName() {
+		return this.name;
+	}
+
+	String getDocumentationUrl() {
+		return this.documentationUrl;
+	}
+
+	void customize(Build build) {
+		if (match(build)) {
+			this.buildCustomizer.accept(build);
+		}
+	}
+
+	boolean match(Build build) {
+		for (String triggeredDependencyId : this.triggeredDependencyIds) {
+			if (build.dependencies().has(triggeredDependencyId)) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+}

--- a/start-site/src/main/java/io/spring/start/site/extension/dependency/springintegration/SpringIntegrationModuleRegistry.java
+++ b/start-site/src/main/java/io/spring/start/site/extension/dependency/springintegration/SpringIntegrationModuleRegistry.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2012-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.spring.start.site.extension.dependency.springintegration;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.Consumer;
+import java.util.stream.Stream;
+
+import io.spring.initializr.generator.buildsystem.Build;
+import io.spring.initializr.generator.buildsystem.Dependency;
+import io.spring.initializr.generator.buildsystem.DependencyScope;
+
+/**
+ * A registry of available {@link SpringIntegrationModule modules}.
+ *
+ * @author Artem  Bilan
+ * @author Stephane Nicoll
+ */
+public final class SpringIntegrationModuleRegistry {
+
+	private final List<SpringIntegrationModule> modules;
+
+	private SpringIntegrationModuleRegistry(List<SpringIntegrationModule> modules) {
+		this.modules = modules;
+	}
+
+	static SpringIntegrationModuleRegistry create(SpringIntegrationModule... modules) {
+		return new SpringIntegrationModuleRegistry(Arrays.asList(modules));
+	}
+
+	static SpringIntegrationModuleRegistry create() {
+		return create(
+				moduleFor("AMQP Module", "amqp", "amqp"),
+				moduleFor("Apache Geode Module", "gemfire", "geode"),
+				moduleFor("HTTP Module", "http", "web"),
+				moduleFor("JDBC Module", "jdbc", "jdbc"),
+				moduleFor("JPA Module", "jpa", "data-jpa"),
+				moduleFor("JMS Module", "jms", "activemq", "artemis"),
+				moduleFor("Apache Kafka Module", "kafka", "kafka"),
+				moduleFor("Mail Module", "mail", "mail"),
+				moduleFor("MongoDB Module", "mongodb", "data-mongodb", "data-mongodb-reactive"),
+				moduleFor("R2DBC Module", "r2dbc", "data-r2dbc"),
+				moduleFor("Redis Module", "redis", "data-redis", "data-redis-reactive"),
+				moduleFor("RSocket Module", "rsocket", "rsocket"),
+				moduleFor("STOMP Module", "stomp", "websocket"),
+				moduleFor("WebSocket Module", "websocket", "websocket"),
+				moduleFor("WebFlux Module", "webflux", "webflux"),
+				moduleFor("Security Module", "security", "security"),
+				moduleFor("Web Services Module", "ws", "web-services"));
+	}
+
+	private static SpringIntegrationModule moduleFor(String name, String id, String... triggerDependencyIds) {
+		return new SpringIntegrationModule(name, referenceLink(id), addDependency(id), triggerDependencyIds);
+	}
+
+	private static Consumer<Build> addDependency(String id) {
+		String module = "spring-integration-" + id;
+		return (build) -> build.dependencies()
+				.add(module, Dependency.withCoordinates("org.springframework.integration", module)
+						.scope(DependencyScope.COMPILE));
+	}
+
+	private static String referenceLink(String href) {
+		return String.format("https://docs.spring.io/spring-integration/reference/html/%s.html", href);
+	}
+
+	Stream<SpringIntegrationModule> modules() {
+		return this.modules.stream();
+	}
+
+}

--- a/start-site/src/main/java/io/spring/start/site/extension/dependency/springintegration/SpringIntegrationProjectGenerationConfiguration.java
+++ b/start-site/src/main/java/io/spring/start/site/extension/dependency/springintegration/SpringIntegrationProjectGenerationConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 the original author or authors.
+ * Copyright 2012-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,8 @@
 
 package io.spring.start.site.extension.dependency.springintegration;
 
+
+import io.spring.initializr.generator.buildsystem.Build;
 import io.spring.initializr.generator.condition.ConditionalOnRequestedDependency;
 import io.spring.initializr.generator.project.ProjectGenerationConfiguration;
 
@@ -25,10 +27,30 @@ import org.springframework.context.annotation.Bean;
  * Configuration for generation of projects that depend on Spring Integration.
  *
  * @author Stephane Nicoll
+ * @author Artem Bilan
  */
 @ProjectGenerationConfiguration
 @ConditionalOnRequestedDependency("integration")
 class SpringIntegrationProjectGenerationConfiguration {
+
+	@Bean
+	public SpringIntegrationModuleRegistry springIntegrationModuleRegistry() {
+		return SpringIntegrationModuleRegistry.create();
+	}
+
+	@Bean
+	public SpringIntegrationBuildCustomizer springIntegrationBuildCustomizer(
+			SpringIntegrationModuleRegistry moduleRegistry) {
+
+		return new SpringIntegrationBuildCustomizer(moduleRegistry);
+	}
+
+	@Bean
+	public SpringIntegrationHelpCustomizer springIntegrationHelpCustomizer(
+			SpringIntegrationModuleRegistry moduleRegistry, Build build) {
+
+		return new SpringIntegrationHelpCustomizer(moduleRegistry, build);
+	}
 
 	@Bean
 	SpringIntegrationTestBuildCustomizer springIntegrationTestBuildCustomizer() {

--- a/start-site/src/main/java/io/spring/start/site/extension/dependency/springintegration/SpringIntegrationTestBuildCustomizer.java
+++ b/start-site/src/main/java/io/spring/start/site/extension/dependency/springintegration/SpringIntegrationTestBuildCustomizer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 the original author or authors.
+ * Copyright 2012-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,20 +20,40 @@ import io.spring.initializr.generator.buildsystem.Build;
 import io.spring.initializr.generator.buildsystem.Dependency;
 import io.spring.initializr.generator.buildsystem.DependencyScope;
 import io.spring.initializr.generator.spring.build.BuildCustomizer;
+import io.spring.initializr.generator.spring.documentation.HelpDocument;
+import io.spring.initializr.generator.spring.documentation.HelpDocumentCustomizer;
 
 /**
  * A {@link BuildCustomizer} that automatically adds {@code spring-integration-test} when
  * Spring Integration is selected.
  *
  * @author Stephane Nicoll
+ * @author Artem Bilan
  */
-class SpringIntegrationTestBuildCustomizer implements BuildCustomizer<Build> {
+class SpringIntegrationTestBuildCustomizer implements BuildCustomizer<Build>, HelpDocumentCustomizer {
+
+	private final SpringIntegrationModule testModule =
+			new SpringIntegrationModule("Test Module",
+					"https://docs.spring.io/spring-integration/reference/html/testing.html",
+					(build) -> build.dependencies()
+							.add("spring-integration-test",
+									Dependency.withCoordinates("org.springframework.integration",
+											"spring-integration-test")
+											.scope(DependencyScope.TEST_COMPILE)),
+					"integration");
 
 	@Override
 	public void customize(Build build) {
-		build.dependencies().add("spring-integration-test",
-				Dependency.withCoordinates("org.springframework.integration", "spring-integration-test")
-						.scope(DependencyScope.TEST_COMPILE));
+		this.testModule.customize(build);
+	}
+
+	@Override public void customize(HelpDocument helpDocument) {
+		helpDocument.gettingStarted().addReferenceDocLink(this.testModule.getDocumentationUrl(),
+				String.format("Spring Integration %s Reference Guide", this.testModule.getName()));
+	}
+
+	@Override public int getOrder() {
+		return 0;
 	}
 
 }

--- a/start-site/src/test/java/io/spring/start/site/extension/dependency/springintegration/SpringIntegrationBuildCustomizerTests.java
+++ b/start-site/src/test/java/io/spring/start/site/extension/dependency/springintegration/SpringIntegrationBuildCustomizerTests.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2012-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.spring.start.site.extension.dependency.springintegration;
+
+import io.spring.initializr.metadata.Dependency;
+import io.spring.initializr.web.project.ProjectRequest;
+import io.spring.start.site.extension.AbstractExtensionTests;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link SpringIntegrationBuildCustomizer}.
+ *
+ * @author Artem Bilan
+ * @author Stephane Nicoll
+ */
+class SpringIntegrationBuildCustomizerTests extends AbstractExtensionTests {
+
+	@Test
+	void springIntegrationTestIsAddedAutomatically() {
+		ProjectRequest request = createProjectRequest("integration");
+		Dependency springIntegrationTest =
+				Dependency.withId("spring-integration-test", "org.springframework.integration",
+						"spring-integration-test", null, Dependency.SCOPE_TEST);
+		assertThat(mavenPom(request)).hasDependency(Dependency.createSpringBootStarter("test", Dependency.SCOPE_TEST))
+				.hasDependency(springIntegrationTest).hasDependenciesSize(3);
+	}
+
+	@Test
+	void springIntegrationModulesAddedIfRequested() {
+		ProjectRequest request =
+				createProjectRequest("integration",
+						"amqp",
+						"geode",
+						"web",
+						"jdbc",
+						"data-jpa",
+						"activemq",
+						"kafka",
+						"mail",
+						"data-mongodb",
+						"data-r2dbc",
+						"data-redis-reactive",
+						"rsocket",
+						"websocket",
+						"webflux",
+						"security",
+						"web-services");
+
+		assertThat(mavenPom(request))
+				.hasDependency(integrationDependency("amqp"))
+				.hasDependency(integrationDependency("gemfire"))
+				.hasDependency(integrationDependency("http"))
+				.hasDependency(integrationDependency("jdbc"))
+				.hasDependency(integrationDependency("jpa"))
+				.hasDependency(integrationDependency("jms"))
+				.hasDependency(integrationDependency("kafka"))
+				.hasDependency(integrationDependency("mail"))
+				.hasDependency(integrationDependency("mongodb"))
+				.hasDependency(integrationDependency("r2dbc"))
+				.hasDependency(integrationDependency("redis"))
+				.hasDependency(integrationDependency("rsocket"))
+				.hasDependency(integrationDependency("stomp"))
+				.hasDependency(integrationDependency("websocket"))
+				.hasDependency(integrationDependency("webflux"))
+				.hasDependency(integrationDependency("security"))
+				.hasDependency(integrationDependency("ws"));
+	}
+
+	private static Dependency integrationDependency(String id) {
+		String integrationModule = "spring-integration-" + id;
+		return Dependency.withId(integrationModule, "org.springframework.integration", integrationModule, null,
+				Dependency.SCOPE_COMPILE);
+	}
+
+}

--- a/start-site/src/test/java/io/spring/start/site/extension/dependency/springintegration/SpringIntegrationProjectGenerationConfigurationTests.java
+++ b/start-site/src/test/java/io/spring/start/site/extension/dependency/springintegration/SpringIntegrationProjectGenerationConfigurationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 the original author or authors.
+ * Copyright 2012-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,9 @@
 
 package io.spring.start.site.extension.dependency.springintegration;
 
+import io.spring.initializr.generator.buildsystem.Build;
 import io.spring.initializr.generator.buildsystem.Dependency;
+import io.spring.initializr.generator.buildsystem.gradle.GradleBuild;
 import io.spring.initializr.generator.project.MutableProjectDescription;
 import io.spring.initializr.generator.spring.build.BuildCustomizer;
 import io.spring.initializr.generator.test.project.ProjectAssetTester;
@@ -29,11 +31,13 @@ import static org.mockito.Mockito.mock;
  * Tests for {@link SpringIntegrationProjectGenerationConfiguration}.
  *
  * @author Stephane Nicoll
+ * @author Artem Bilan
  */
 class SpringIntegrationProjectGenerationConfigurationTests {
 
 	private final ProjectAssetTester projectTester = new ProjectAssetTester()
-			.withConfiguration(SpringIntegrationProjectGenerationConfiguration.class);
+			.withConfiguration(SpringIntegrationProjectGenerationConfiguration.class)
+			.withBean(Build.class, GradleBuild::new);
 
 	@Test
 	void springIntegrationTestWithIntegration() {

--- a/start-site/src/test/java/io/spring/start/site/extension/dependency/springintegration/SpringIntegrationTestBuildCustomizerTests.java
+++ b/start-site/src/test/java/io/spring/start/site/extension/dependency/springintegration/SpringIntegrationTestBuildCustomizerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 the original author or authors.
+ * Copyright 2012-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,19 +23,22 @@ import io.spring.initializr.generator.buildsystem.maven.MavenBuild;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
 
 /**
  * Tests for {@link SpringIntegrationTestBuildCustomizer}.
  *
  * @author Stephane Nicoll
+ * @author Artem Bilan
  */
 class SpringIntegrationTestBuildCustomizerTests {
 
 	@Test
-	void customizeAddsSpringRabbitTest() {
+	void customizeAddsSpringIntegrationTest() {
 		Build build = new MavenBuild();
+		build.dependencies().add("integration", mock(Dependency.class));
 		new SpringIntegrationTestBuildCustomizer().customize(build);
-		assertThat(build.dependencies().ids()).containsOnly("spring-integration-test");
+		assertThat(build.dependencies().ids()).contains("integration", "spring-integration-test");
 		Dependency springIntegrationTest = build.dependencies().get("spring-integration-test");
 		assertThat(springIntegrationTest.getGroupId()).isEqualTo("org.springframework.integration");
 		assertThat(springIntegrationTest.getArtifactId()).isEqualTo("spring-integration-test");


### PR DESCRIPTION
Fixes https://github.com/spring-io/start.spring.io/issues/600

Introduce an infrastructure for Spring Integration modules
and add respective dependencies into the generated POM
& doc links into a HELP.md when specific existing entry
is selected from the start.spring.io
