### PR TITLE
Invalid Spring Cloud Contract Gradle plugin configuration with Spring Cloud 2020.0.x

### DIFF
--- a/start-site/src/main/java/io/spring/start/site/extension/dependency/springcloud/SpringCloudContractGradleBuildCustomizer.java
+++ b/start-site/src/main/java/io/spring/start/site/extension/dependency/springcloud/SpringCloudContractGradleBuildCustomizer.java
@@ -41,6 +41,8 @@ class SpringCloudContractGradleBuildCustomizer implements BuildCustomizer<Gradle
 
 	private static final VersionRange SPRING_BOOT_2_2_OR_LATER = VersionParser.DEFAULT.parseRange("2.2.0.M1");
 
+	private static final VersionRange SPRING_CLOUD_CONTRACT_3_0_OR_LATER = VersionParser.DEFAULT.parseRange("3.0.0.M4");
+
 	private static final MavenRepository SPRING_MILESTONES = MavenRepository
 			.withIdAndUrl("spring-milestones", "https://repo.spring.io/milestone").name("Spring Milestones").build();
 
@@ -74,7 +76,7 @@ class SpringCloudContractGradleBuildCustomizer implements BuildCustomizer<Gradle
 		build.plugins().apply("spring-cloud-contract");
 		build.tasks().customize("contracts", (task) -> {
 			if (SPRING_BOOT_2_2_OR_LATER.match(platformVersion)) {
-				task.attribute("targetFramework",
+				task.attribute("testFramework",
 						"org.springframework.cloud.contract.verifier.config.TestFramework.JUNIT5");
 			}
 			if (build.dependencies().has("webflux")) {
@@ -84,6 +86,9 @@ class SpringCloudContractGradleBuildCustomizer implements BuildCustomizer<Gradle
 								.scope(DependencyScope.TEST_COMPILE));
 			}
 		});
+		if (SPRING_CLOUD_CONTRACT_3_0_OR_LATER.match(VersionParser.DEFAULT.parse(sccPluginVersion))) {
+			build.tasks().customize("contractTest", (task) -> task.invoke("useJUnitPlatform"));
+		}
 		configurePluginRepositories(build, sccPluginVersion);
 	}
 

--- a/start-site/src/test/java/io/spring/start/site/extension/dependency/springcloud/SpringCloudContractGradleBuildCustomizerTests.java
+++ b/start-site/src/test/java/io/spring/start/site/extension/dependency/springcloud/SpringCloudContractGradleBuildCustomizerTests.java
@@ -61,7 +61,21 @@ class SpringCloudContractGradleBuildCustomizerTests extends AbstractExtensionTes
 		ProjectRequest projectRequest = createProjectRequest("cloud-contract-verifier");
 		projectRequest.setBootVersion("2.2.0.RELEASE");
 		assertThat(gradleBuild(projectRequest)).containsSubsequence("contracts {",
-				"targetFramework = org.springframework.cloud.contract.verifier.config.TestFramework.JUNIT5");
+				"testFramework = org.springframework.cloud.contract.verifier.config.TestFramework.JUNIT5");
+	}
+
+	@Test
+	void springCloudContractVerifierPlugin2WithNoContractTestConfiguration() {
+		ProjectRequest projectRequest = createProjectRequest("cloud-contract-verifier");
+		projectRequest.setBootVersion("2.3.7.RELEASE");
+		assertThat(gradleBuild(projectRequest)).doesNotContain("contractTest {");
+	}
+
+	@Test
+	void springCloudContractVerifierPlugin30ContractTestWithJUnit5ByDefault() {
+		ProjectRequest projectRequest = createProjectRequest("cloud-contract-verifier");
+		projectRequest.setBootVersion("2.4.1");
+		assertThat(gradleBuild(projectRequest)).containsSubsequence("contractTest {", "useJUnitPlatform()");
 	}
 
 	@Test


### PR DESCRIPTION
The currently generated configuration for the Spring Cloud Contract Gradle plugin does not work with the latest version of the plugin.

 - `targetFramework` was deprecated attribute and it is now deleted. As the new attribute (`testFramework`) was available since at least Spring Boot 2.2.x use it instead so the configuration can work with all version after Spring Boot 2.2.x
 - Since Spring Cloud Contract Gradle plugin 2.2.0.M1 the generated tests are executed in separate task - `contractTest`. This tasks also need to be configured to use JUnit Platform (JUnit 5). Otherwise the generated tests are not going to be run.
    
#296 mentions that after JUnit 5 is made default for Spring Cloud Contract Gradle plugin the configuration should be revisited. As JUnit 5 is now the default (see spring-cloud/spring-cloud-contract#1249) please advice how to proceed. Change the configuration so that the `testFramework` is added only for certain Spring Boot version range?

Fixes #612 
