### PR TITLE
Add spring boot config import info

### DIFF
--- a/start-site/src/main/java/io/spring/start/site/extension/dependency/springcloud/SpringBootConfigImportSection.java
+++ b/start-site/src/main/java/io/spring/start/site/extension/dependency/springcloud/SpringBootConfigImportSection.java
@@ -32,9 +32,9 @@ import io.spring.initializr.generator.spring.documentation.PreDefinedSection;
 class SpringBootConfigImportSection extends PreDefinedSection {
 
 	SpringBootConfigImportSection(TemplateRenderer templateRenderer,
-			Set<SpringCloudSpringBootConfigImportHelpDocumentCustomizer.ConfigSource> configSources) {
+			Set<SpringCloudConfigImportHelpDocumentCustomizer.ConfigSource> configSources) {
 		super("Spring Boot Config Data Import");
-		BulletedSection<SpringCloudSpringBootConfigImportHelpDocumentCustomizer.ConfigSource> configSourcesSection = new BulletedSection<>(
+		BulletedSection<SpringCloudConfigImportHelpDocumentCustomizer.ConfigSource> configSourcesSection = new BulletedSection<>(
 				templateRenderer, "spring-boot-config-data-import");
 		configSources.forEach(configSourcesSection::addItem);
 		addSection(configSourcesSection);

--- a/start-site/src/main/java/io/spring/start/site/extension/dependency/springcloud/SpringBootConfigImportSection.java
+++ b/start-site/src/main/java/io/spring/start/site/extension/dependency/springcloud/SpringBootConfigImportSection.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2012-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.spring.start.site.extension.dependency.springcloud;
+
+import java.util.Set;
+
+import io.spring.initializr.generator.io.template.TemplateRenderer;
+import io.spring.initializr.generator.io.text.BulletedSection;
+import io.spring.initializr.generator.io.text.Section;
+import io.spring.initializr.generator.spring.documentation.PreDefinedSection;
+
+/**
+ * A {@link Section} that provides information about Spring Boot config data import setup
+ * for Spring Cloud distributed configuration.
+ *
+ * @author Olga Maciaszek-Sharma
+ */
+class SpringBootConfigImportSection extends PreDefinedSection {
+
+	SpringBootConfigImportSection(TemplateRenderer templateRenderer,
+			Set<SpringCloudSpringBootConfigImportHelpDocumentCustomizer.ConfigSource> configSources) {
+		super("Spring Boot Config Data Import");
+		BulletedSection<SpringCloudSpringBootConfigImportHelpDocumentCustomizer.ConfigSource> configSourcesSection = new BulletedSection<>(
+				templateRenderer, "spring-boot-config-data-import");
+		configSources.forEach(configSourcesSection::addItem);
+		addSection(configSourcesSection);
+	}
+
+}

--- a/start-site/src/main/java/io/spring/start/site/extension/dependency/springcloud/SpringCloudConfigImportHelpDocumentCustomizer.java
+++ b/start-site/src/main/java/io/spring/start/site/extension/dependency/springcloud/SpringCloudConfigImportHelpDocumentCustomizer.java
@@ -34,7 +34,7 @@ import io.spring.initializr.generator.version.VersionRange;
  *
  * @author Olga Maciaszek-Sharma
  */
-class SpringCloudSpringBootConfigImportHelpDocumentCustomizer implements HelpDocumentCustomizer {
+class SpringCloudConfigImportHelpDocumentCustomizer implements HelpDocumentCustomizer {
 
 	private static final VersionRange SPRING_BOOT_2_4_0_OR_LATER = VersionParser.DEFAULT.parseRange("2.4.0");
 
@@ -42,8 +42,7 @@ class SpringCloudSpringBootConfigImportHelpDocumentCustomizer implements HelpDoc
 
 	private final TemplateRenderer templateRenderer;
 
-	SpringCloudSpringBootConfigImportHelpDocumentCustomizer(ProjectDescription description,
-			TemplateRenderer templateRenderer) {
+	SpringCloudConfigImportHelpDocumentCustomizer(ProjectDescription description, TemplateRenderer templateRenderer) {
 		this.description = description;
 		this.templateRenderer = templateRenderer;
 	}
@@ -58,8 +57,8 @@ class SpringCloudSpringBootConfigImportHelpDocumentCustomizer implements HelpDoc
 				.collect(Collectors.toMap((data) -> data[0], (data) -> new ConfigSource(data[1], data[2], data[3])));
 
 		return configSources.entrySet().stream()
-				.filter((configSourceEntry) -> buildDependencies.contains(configSourceEntry.getKey())).map(Map.Entry::getValue)
-				.collect(Collectors.toSet());
+				.filter((configSourceEntry) -> buildDependencies.contains(configSourceEntry.getKey()))
+				.map(Map.Entry::getValue).collect(Collectors.toSet());
 	}
 
 	@Override

--- a/start-site/src/main/java/io/spring/start/site/extension/dependency/springcloud/SpringCloudProjectGenerationConfiguration.java
+++ b/start-site/src/main/java/io/spring/start/site/extension/dependency/springcloud/SpringCloudProjectGenerationConfiguration.java
@@ -105,9 +105,9 @@ public class SpringCloudProjectGenerationConfiguration {
 	}
 
 	@Bean
-	public SpringCloudSpringBootConfigImportHelpDocumentCustomizer springCloudConfigGradleBuildCustomizer(
+	public SpringCloudConfigImportHelpDocumentCustomizer springCloudConfigGradleBuildCustomizer(
 			TemplateRenderer templateRenderer) {
-		return new SpringCloudSpringBootConfigImportHelpDocumentCustomizer(this.description, templateRenderer);
+		return new SpringCloudConfigImportHelpDocumentCustomizer(this.description, templateRenderer);
 	}
 
 }

--- a/start-site/src/main/java/io/spring/start/site/extension/dependency/springcloud/SpringCloudProjectGenerationConfiguration.java
+++ b/start-site/src/main/java/io/spring/start/site/extension/dependency/springcloud/SpringCloudProjectGenerationConfiguration.java
@@ -104,4 +104,10 @@ public class SpringCloudProjectGenerationConfiguration {
 		return new SpringCloudCircuitBreakerBuildCustomizer(this.metadata, this.description);
 	}
 
+	@Bean
+	public SpringCloudSpringBootConfigImportHelpDocumentCustomizer springCloudConfigGradleBuildCustomizer(
+			TemplateRenderer templateRenderer) {
+		return new SpringCloudSpringBootConfigImportHelpDocumentCustomizer(this.description, templateRenderer);
+	}
+
 }

--- a/start-site/src/main/java/io/spring/start/site/extension/dependency/springcloud/SpringCloudSpringBootConfigImportHelpDocumentCustomizer.java
+++ b/start-site/src/main/java/io/spring/start/site/extension/dependency/springcloud/SpringCloudSpringBootConfigImportHelpDocumentCustomizer.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2012-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.spring.start.site.extension.dependency.springcloud;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import io.spring.initializr.generator.io.template.TemplateRenderer;
+import io.spring.initializr.generator.project.ProjectDescription;
+import io.spring.initializr.generator.spring.documentation.HelpDocument;
+import io.spring.initializr.generator.spring.documentation.HelpDocumentCustomizer;
+import io.spring.initializr.generator.version.Version;
+import io.spring.initializr.generator.version.VersionParser;
+import io.spring.initializr.generator.version.VersionRange;
+
+/**
+ * Adds default imports for Spring Cloud Config clients and integrations.
+ *
+ * @author Olga Maciaszek-Sharma
+ */
+class SpringCloudSpringBootConfigImportHelpDocumentCustomizer implements HelpDocumentCustomizer {
+
+	private static final VersionRange SPRING_BOOT_2_4_0_OR_LATER = VersionParser.DEFAULT.parseRange("2.4.0");
+
+	private final ProjectDescription description;
+
+	private final TemplateRenderer templateRenderer;
+
+	SpringCloudSpringBootConfigImportHelpDocumentCustomizer(ProjectDescription description,
+			TemplateRenderer templateRenderer) {
+		this.description = description;
+		this.templateRenderer = templateRenderer;
+	}
+
+	Set<ConfigSource> getConfigSources() {
+		Set<String> buildDependencies = this.description.getRequestedDependencies().keySet();
+		Map<String, ConfigSource> configSources = Stream
+				.of(new String[][] { { "cloud-config-client", "configserver", "Config Server", "8888" },
+						{ "cloud-starter-consul-config", "consul", "Consul", "8500" },
+						{ "cloud-starter-zookeeper-config", "zookeeper", "Zookeeper", "2181" },
+						{ "cloud-starter-vault-config", "vault", "Vault", "8200" } })
+				.collect(Collectors.toMap((data) -> data[0], (data) -> new ConfigSource(data[1], data[2], data[3])));
+
+		return configSources.entrySet().stream()
+				.filter((configSourceEntry) -> buildDependencies.contains(configSourceEntry.getKey())).map(Map.Entry::getValue)
+				.collect(Collectors.toSet());
+	}
+
+	@Override
+	public void customize(HelpDocument helpDocument) {
+		Version platformVersion = this.description.getPlatformVersion();
+		if (SPRING_BOOT_2_4_0_OR_LATER.match((platformVersion))) {
+			Set<ConfigSource> configSources = getConfigSources();
+			if (!configSources.isEmpty()) {
+				helpDocument.gettingStarted().addReferenceDocLink(
+						"https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#boot-features-external-config-files",
+						"Spring Boot External Application Properties");
+				helpDocument.addSection(new SpringBootConfigImportSection(this.templateRenderer, configSources));
+			}
+		}
+	}
+
+	protected static class ConfigSource {
+
+		String key;
+
+		String name;
+
+		String defaultPort;
+
+		ConfigSource(String key, String name, String defaultPort) {
+			this.key = key;
+			this.name = name;
+			this.defaultPort = defaultPort;
+		}
+
+	}
+
+}

--- a/start-site/src/main/resources/application.yml
+++ b/start-site/src/main/resources/application.yml
@@ -1037,6 +1037,13 @@ initializr:
           description: Client that connects to a Spring Cloud Config Server to fetch the application's configuration.
           groupId: org.springframework.cloud
           artifactId: spring-cloud-starter-config
+          links:
+            - rel: reference
+              href: https://docs.spring.io/spring-cloud-config/docs/current/reference/html/#_spring_cloud_config_client
+              description: Config Server Client
+            - rel: reference
+              href: https://docs.spring.io/spring-cloud-config/docs/current/reference/html/#config-data-import
+              description: SpringBoot Config Data Import
         - name: Config Server
           id: cloud-config-server
           description: Central management for configuration via Git, SVN, or HashiCorp Vault.
@@ -1051,16 +1058,37 @@ initializr:
           description: Provides client-side support for externalized configuration in a distributed system. Using HashiCorp's Vault you have a central place to manage external secret properties for applications across all environments.
           groupId: org.springframework.cloud
           artifactId: spring-cloud-starter-vault-config
+          links:
+            - rel: reference
+              href: https://docs.spring.io/spring-cloud-vault/docs/current/reference/html/#_quick_start
+              description: Spring Cloud Vault
+            - rel: reference
+              href: https://docs.spring.io/spring-cloud-vault/docs/current/reference/html/#vault.configdata.locations
+              description: SpringBoot Config Data Import
         - name: Apache Zookeeper Configuration
           id: cloud-starter-zookeeper-config
           description: Enable and configure common patterns inside your application and build large distributed systems with Apache Zookeeper based components. The provided patterns include Service Discovery and Configuration.
           groupId: org.springframework.cloud
           artifactId: spring-cloud-starter-zookeeper-config
+          links:
+            - rel: reference
+              href: https://docs.spring.io/spring-cloud-zookeeper/docs/current/reference/html/#spring-cloud-zookeeper-config
+              description: Distributed Configuration with Zookeeper
+            - rel: reference
+              href: https://docs.spring.io/spring-cloud-zookeeper/docs/current/reference/html/#config-data-import
+              description: Spring Boot Config Data Import
         - name: Consul Configuration
           id: cloud-starter-consul-config
           description: Enable and configure the common patterns inside your application and build large distributed systems with Hashicorp’s Consul. The patterns provided include Service Discovery, Distributed Configuration and Control Bus.
           groupId: org.springframework.cloud
           artifactId: spring-cloud-starter-consul-config
+          links:
+            - rel: reference
+              href: https://docs.spring.io/spring-cloud-consul/docs/current/reference/html/#spring-cloud-consul-config
+              description: Distributed Configuration With Spring Cloud Consul
+            - rel: reference
+              href: https://docs.spring.io/spring-cloud-consul/docs/current/reference/html/#config-data-import
+              description: Spring Boot Config Data Import
     - name: Spring Cloud Discovery
       bom: spring-cloud
       content:

--- a/start-site/src/main/resources/templates/spring-boot-config-data-import.mustache
+++ b/start-site/src/main/resources/templates/spring-boot-config-data-import.mustache
@@ -1,0 +1,11 @@
+Spring Boot 2.4 introduced a new way to import configuration data via the `spring.config.import` property. This is now the default way to get configuration.
+
+{{#items}}
+
+You might want to optionally connect to {{name}} running at a default `localhost:{{defaultPort}}` location for configuration by setting the following in `application.properties`:
+
+`spring.config.import=optional:{{key}}:`
+
+{{/items}}
+
+You can find more information in the `SpringBoot Config Data Import` and `Spring Boot External Application Properties` documentation sections linked above.

--- a/start-site/src/test/java/io/spring/start/site/extension/dependency/springcloud/SpringCloudConfigImportHelpDocumentCustomizerTests.java
+++ b/start-site/src/test/java/io/spring/start/site/extension/dependency/springcloud/SpringCloudConfigImportHelpDocumentCustomizerTests.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2012-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.spring.start.site.extension.dependency.springcloud;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import io.spring.initializr.generator.test.io.TextAssert;
+import io.spring.initializr.generator.test.project.ProjectStructure;
+import io.spring.initializr.web.project.ProjectRequest;
+import io.spring.start.site.extension.AbstractExtensionTests;
+import org.assertj.core.api.ListAssert;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for {@link SpringCloudConfigImportHelpDocumentCustomizer}.
+ *
+ * @author Olga Maciaszek-Sharma
+ */
+class SpringCloudConfigImportHelpDocumentCustomizerTests extends AbstractExtensionTests {
+
+	@Test
+	void sectionAddedWhenConfigClientDependenciesPresent() {
+		ProjectRequest request = createProjectRequest();
+		request.setBootVersion("2.4.0");
+		request.setDependencies(Arrays.asList("cloud-config-client", "cloud-starter-consul-config",
+				"cloud-starter-vault-config", "cloud-starter-zookeeper-config"));
+		assertHelpDocument(request).contains("# Spring Boot Config Data Import",
+				"`spring.config.import=optional:vault:`", "`spring.config.import=optional:consul:`",
+				"`spring.config.import=optional:configserver:`", "`spring.config.import=optional:zookeeper:`");
+	}
+
+	@Test
+	void sectionNotAddedWhenNoConfigClientDependencies() {
+		ProjectRequest request = createProjectRequest();
+		request.setBootVersion("2.4.0");
+		request.setDependencies(Collections.singletonList("cloud-config-server"));
+		assertHelpDocument(request).doesNotContain("# Spring Boot Config Data Import");
+	}
+
+	@Test
+	void sectionNotAddedWhenOlderSpringBootVersion() {
+		ProjectRequest request = createProjectRequest();
+		request.setBootVersion("2.3.9.RELEASE");
+		request.setDependencies(Arrays.asList("cloud-config-client", "cloud-starter-consul-config",
+				"cloud-starter-vault-config", "cloud-starter-zookeeper-config"));
+		assertHelpDocument(request).doesNotContain("# Spring Boot Config Data Import");
+	}
+
+	private ListAssert<String> assertHelpDocument(ProjectRequest projectRequest) {
+		ProjectStructure project = generateProject(projectRequest);
+		return new TextAssert(project.getProjectDirectory().resolve("HELP.md")).lines();
+	}
+
+}


### PR DESCRIPTION
Add information on using Spring Boot Config Imports with Spring Cloud Distributed Configuration to `HELP.md`.