### PR TITLE
Add additional reference links for Spring Cloud config clients

### DIFF
--- a/start-site/src/main/resources/application.yml
+++ b/start-site/src/main/resources/application.yml
@@ -1128,14 +1128,8 @@ initializr:
           artifactId: spring-cloud-starter-config
           links:
             - rel: reference
-              href: https://docs.spring.io/spring-cloud-config/docs/current/reference/html/#_spring_cloud_config_client
+              href: https://docs.spring.io/spring-cloud-config/docs/current/reference/html/#_client_side_usage
               description: Config Server Client
-            - rel: reference
-              href: https://docs.spring.io/spring-cloud-config/docs/current/reference/html/#config-data-import
-              description: SpringBoot Config Data Import
-            - rel: reference
-              href: https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#boot-features-external-config-files
-              description: Spring Boot External Application Properties
         - name: Config Server
           id: cloud-config-server
           description: Central management for configuration via Git, SVN, or HashiCorp Vault.
@@ -1154,14 +1148,8 @@ initializr:
           artifactId: spring-cloud-starter-vault-config
           links:
             - rel: reference
-              href: https://docs.spring.io/spring-cloud-vault/docs/current/reference/html/#quick_start
+              href: https://docs.spring.io/spring-cloud-vault/docs/current/reference/html/#quick-start
               description: Spring Cloud Vault
-            - rel: reference
-              href: https://docs.spring.io/spring-cloud-vault/docs/current/reference/html/#vault.configdata.locations
-              description: ConfigData Locations
-            - rel: reference
-              href: https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#boot-features-external-config-files
-              description: Spring Boot External Application Properties
         - name: Apache Zookeeper Configuration
           id: cloud-starter-zookeeper-config
           description: Enable and configure common patterns inside your application and build large distributed systems with Apache Zookeeper based components. The provided patterns include Service Discovery and Configuration.
@@ -1169,14 +1157,8 @@ initializr:
           artifactId: spring-cloud-starter-zookeeper-config
           links:
             - rel: reference
-              href: https://docs.spring.io/spring-cloud-zookeeper/docs/current/reference/html/#spring-cloud-zookeeper-config
+              href: https://docs.spring.io/spring-cloud-zookeeper/docs/current/reference/html/#distributed-configuration-usage
               description: Distributed Configuration with Zookeeper
-            - rel: reference
-              href: https://docs.spring.io/spring-cloud-zookeeper/docs/current/reference/html/#config-data-import
-              description: Spring Boot Config Data Import
-            - rel: reference
-              href: https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#boot-features-external-config-files
-              description: Spring Boot External Application Properties
         - name: Consul Configuration
           id: cloud-starter-consul-config
           description: Enable and configure the common patterns inside your application and build large distributed systems with Hashicorp’s Consul. The patterns provided include Service Discovery, Distributed Configuration and Control Bus.
@@ -1184,14 +1166,8 @@ initializr:
           artifactId: spring-cloud-starter-consul-config
           links:
             - rel: reference
-              href: https://docs.spring.io/spring-cloud-consul/docs/current/reference/html/#spring-cloud-consul-config
+              href: https://docs.spring.io/spring-cloud-consul/docs/current/reference/html/#distributed-configuration-usage
               description: Distributed Configuration With Spring Cloud Consul
-            - rel: reference
-              href: https://docs.spring.io/spring-cloud-consul/docs/current/reference/html/#config-data-import
-              description: Spring Boot Config Data Import
-            - rel: reference
-              href: https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#boot-features-external-config-files
-              description: Spring Boot External Application Properties
     - name: Spring Cloud Discovery
       bom: spring-cloud
       content:

--- a/start-site/src/main/resources/application.yml
+++ b/start-site/src/main/resources/application.yml
@@ -1036,6 +1036,16 @@ initializr:
           description: Client that connects to a Spring Cloud Config Server to fetch the application's configuration.
           groupId: org.springframework.cloud
           artifactId: spring-cloud-starter-config
+          links:
+            - rel: reference
+              href: https://docs.spring.io/spring-cloud-config/docs/current/reference/html/#_spring_cloud_config_client
+              description: Config Server Client
+            - rel: reference
+              href: https://docs.spring.io/spring-cloud-config/docs/current/reference/html/#config-data-import
+              description: SpringBoot Config Data Import
+            - rel: reference
+              href: https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#boot-features-external-config-files
+              description: Spring Boot External Application Properties
         - name: Config Server
           id: cloud-config-server
           description: Central management for configuration via Git, SVN, or HashiCorp Vault.
@@ -1050,16 +1060,46 @@ initializr:
           description: Provides client-side support for externalized configuration in a distributed system. Using HashiCorp's Vault you have a central place to manage external secret properties for applications across all environments.
           groupId: org.springframework.cloud
           artifactId: spring-cloud-starter-vault-config
+          links:
+            - rel: reference
+              href: https://docs.spring.io/spring-cloud-vault/docs/current/reference/html/#_quick_start
+              description: Spring Cloud Vault
+            - rel: reference
+              href: https://docs.spring.io/spring-cloud-vault/docs/current/reference/html/#vault.configdata.locations
+              description: ConfigData Locations
+            - rel: reference
+              href: https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#boot-features-external-config-files
+              description: Spring Boot External Application Properties
         - name: Apache Zookeeper Configuration
           id: cloud-starter-zookeeper-config
           description: Enable and configure common patterns inside your application and build large distributed systems with Apache Zookeeper based components. The provided patterns include Service Discovery and Configuration.
           groupId: org.springframework.cloud
           artifactId: spring-cloud-starter-zookeeper-config
+          links:
+            - rel: reference
+              href: https://docs.spring.io/spring-cloud-zookeeper/docs/current/reference/html/#spring-cloud-zookeeper-config
+              description: Distributed Configuration with Zookeeper
+            - rel: reference
+              href: https://docs.spring.io/spring-cloud-zookeeper/docs/current/reference/html/#config-data-import
+              description: Spring Boot Config Data Import
+            - rel: reference
+              href: https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#boot-features-external-config-files
+              description: Spring Boot External Application Properties
         - name: Consul Configuration
           id: cloud-starter-consul-config
           description: Enable and configure the common patterns inside your application and build large distributed systems with Hashicorp’s Consul. The patterns provided include Service Discovery, Distributed Configuration and Control Bus.
           groupId: org.springframework.cloud
           artifactId: spring-cloud-starter-consul-config
+          links:
+            - rel: reference
+              href: https://docs.spring.io/spring-cloud-consul/docs/current/reference/html/#spring-cloud-consul-config
+              description: Distributed Configuration With Spring Cloud Consul
+            - rel: reference
+              href: https://docs.spring.io/spring-cloud-consul/docs/current/reference/html/#config-data-import
+              description: Spring Boot Config Data Import
+            - rel: reference
+              href: https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#boot-features-external-config-files
+              description: Spring Boot External Application Properties
     - name: Spring Cloud Discovery
       bom: spring-cloud
       content:

--- a/start-site/src/main/resources/application.yml
+++ b/start-site/src/main/resources/application.yml
@@ -1128,7 +1128,7 @@ initializr:
           artifactId: spring-cloud-starter-config
           links:
             - rel: reference
-              href: https://docs.spring.io/spring-cloud-config/docs/current/reference/html/#_client_side_usage
+              href: https://docs.spring.io/spring-cloud-config/docs/current/reference/html/#client_side_usage
               description: Config Server Client
         - name: Config Server
           id: cloud-config-server

--- a/start-site/src/main/resources/application.yml
+++ b/start-site/src/main/resources/application.yml
@@ -1062,7 +1062,7 @@ initializr:
           artifactId: spring-cloud-starter-vault-config
           links:
             - rel: reference
-              href: https://docs.spring.io/spring-cloud-vault/docs/current/reference/html/#_quick_start
+              href: https://docs.spring.io/spring-cloud-vault/docs/current/reference/html/#quick_start
               description: Spring Cloud Vault
             - rel: reference
               href: https://docs.spring.io/spring-cloud-vault/docs/current/reference/html/#vault.configdata.locations


### PR DESCRIPTION
Add reference links related to external config imports to `HELP.md` for SC Config Client projects.