### PR TITLE
Upgrade to MyBatis Spring 2.2

### DIFF
--- a/start-site/src/main/resources/application.yml
+++ b/start-site/src/main/resources/application.yml
@@ -501,7 +501,6 @@ initializr:
               description: R2DBC Homepage
         - name: MyBatis Framework
           id: mybatis
-          compatibilityRange: "[2.0.0.RELEASE,2.5.0-M1)"
           description: Persistence framework with support for custom SQL, stored procedures and advanced mappings. MyBatis couples objects with stored procedures or SQL statements using a XML descriptor or annotations.
           links:
             - rel: guide
@@ -514,6 +513,8 @@ initializr:
           mappings:
             - compatibilityRange: "[2.1.0.RELEASE,2.5.0-M1)"
               version: 2.1.4
+            - compatibilityRange: "2.5.0-M1"
+              version: 2.2.0
         - name: Liquibase Migration
           id: liquibase
           description: Liquibase database migration and source control library.


### PR DESCRIPTION
The mybatis-spring-boot 2.2.0(switch baseline to spring-boot 2.5.x) has been released at today.

* https://github.com/mybatis/spring-boot-starter/releases/tag/mybatis-spring-boot-2.2.0

Note: The MyBatis Team will be maintenance to following two lines.

* 2.2.x : for Spring Boot 2.5+ user
* 2.1.x : for Spring Boot 2.4 or under user
