### PR TITLE
Upgrade to Okta Spring Boot 2.1.0

### DIFF
--- a/start-site/src/main/resources/application.yml
+++ b/start-site/src/main/resources/application.yml
@@ -430,6 +430,8 @@ initializr:
               version: 1.5.1
             - compatibilityRange: "[2.4.1,2.5.0-M1)"
               version: 2.0.1
+            - compatibilityRange: "[2.5.0,2.6.0-M1)"
+              version: 2.1.0
           links:
             - rel: guide
               href: https://github.com/okta/samples-java-spring/tree/master/okta-hosted-login


### PR DESCRIPTION
The okta-spring-boot-starter is now testing against Spring Boot 2.5.x

