### PR TITLE
Add Micrometer Registry for Dynatrace

### DIFF
--- a/start-site/src/main/java/io/spring/start/site/extension/dependency/observability/ObservabilityBuildCustomizer.java
+++ b/start-site/src/main/java/io/spring/start/site/extension/dependency/observability/ObservabilityBuildCustomizer.java
@@ -30,7 +30,7 @@ import io.spring.initializr.generator.spring.build.BuildCustomizer;
 class ObservabilityBuildCustomizer implements BuildCustomizer<Build> {
 
 	private static final List<String> MICROMETER_REGISTRY_IDS = Arrays.asList("datadog", "graphite", "influx",
-			"new-relic");
+			"new-relic", "dynatrace");
 
 	@Override
 	public void customize(Build build) {

--- a/start-site/src/main/resources/application.yml
+++ b/start-site/src/main/resources/application.yml
@@ -1004,6 +1004,19 @@ initializr:
             - compatibilityRange: "[2.0.0.RELEASE,2.4.0.M3]"
               artifactId: spring-cloud-starter-zipkin
               starter: true
+        - name: Dynatrace
+          id: dynatrace
+          groupId: io.micrometer
+          artifactId: micrometer-registry-dynatrace
+          scope: runtime
+          starter: false
+          description: Publish Micrometer metrics to Dynatrace, a Software Intelligence Platform featuring application performance monitoring (APM), artificial intelligence for operations (AIOps), IT infrastructure monitoring, digital experience management (DEM), and digital business analytics capabilities.
+          links:
+            - rel: reference
+              href: https://docs.spring.io/spring-boot/docs/{bootVersion}/reference/html/actuator.html#actuator.metrics.export.dynatrace
+            - rel: home
+              href: https://www.dynatrace.com/
+              description: Dynatrace Website
     - name: Testing
       content:
         - name: Spring REST Docs

--- a/start-site/src/test/java/io/spring/start/site/extension/dependency/observability/ObservabilityBuildCustomizerTests.java
+++ b/start-site/src/test/java/io/spring/start/site/extension/dependency/observability/ObservabilityBuildCustomizerTests.java
@@ -58,6 +58,11 @@ class ObservabilityBuildCustomizerTests extends AbstractExtensionTests {
 				actuator.getArtifactId());
 	}
 
+	@Test
+	void actuatorIsAddedWithDynatrace() {
+		assertThat(generateProject("dynatrace")).mavenBuild().hasDependency(getDependency("actuator"));
+	}
+
 	private ProjectStructure generateProject(String... dependencies) {
 		ProjectRequest request = createProjectRequest(dependencies);
 		request.setType("maven-build");


### PR DESCRIPTION
This PR adds a entry for the Dynatrace exporter for Micrometer. This is not a starter, but a component that users can optionally choose in order to export metrics collected by Micrometer to Dynatrace. Therefore, I did not open a New Entry proposal, as it seems to be aimed at new starters. Please let me know if one is needed either way, and I will gladly open one.

## Licence
This project follows the guidelines of the Micrometer project and includes `micrometer-core`, which is released under a Apache 2.0 license. It has a dependency on the `'com.dynatrace.metric.util:dynatrace-metric-utils-java'` library, which is developed by Dynatrace and is also released under the Apache 2.0 license (https://search.maven.org/artifact/com.dynatrace.metric.util/dynatrace-metric-utils-java; https://github.com/dynatrace-oss/dynatrace-metric-utils-java). A compile-time dependency to `'org.slf4j:slf4j-api`, which is released under the MIT license is also included. Finally, for testing this registry depends on `'com.fasterxml.jackson.core:jackson-databind'` and `micrometer-test`, both of which are licensed under the Apache license.

## Links to additional resources
Each entry can be associated with one or several links. Please provide at least a link to
a sample and the reference documentation:

* Reference documentation:
	* https://docs.spring.io/spring-boot/docs/current/reference/html/actuator.html#actuator.metrics.export.dynatrace
	* https://micrometer.io/docs/registry/dynatrace
* Sample:
	* https://github.com/micrometer-metrics/micrometer/blob/main/samples/micrometer-samples-boot2/src/main/java/io/micrometer/boot2/samples/DynatraceSampleV1.java
	* https://github.com/micrometer-metrics/micrometer/blob/main/samples/micrometer-samples-boot2/src/main/java/io/micrometer/boot2/samples/DynatraceSampleV2.java
	* https://github.com/micrometer-metrics/micrometer/blob/1.7.x/samples/micrometer-samples-boot2/src/main/java/io/micrometer/boot2/samples/DynatraceSample.java