### PR TITLE
Upgrade to Native Buildtools 0.9.5

### DIFF
--- a/start-site/src/main/java/io/spring/start/site/extension/dependency/springnative/SpringNativeBuildtoolsVersionResolver.java
+++ b/start-site/src/main/java/io/spring/start/site/extension/dependency/springnative/SpringNativeBuildtoolsVersionResolver.java
@@ -31,7 +31,9 @@ import io.spring.initializr.generator.version.VersionRange;
 abstract class SpringNativeBuildtoolsVersionResolver {
 
 	private static final List<NativeBuildtoolsRange> ranges = Arrays.asList(
-			new NativeBuildtoolsRange("[0.9.0,0.10.0-M1)", null), new NativeBuildtoolsRange("0.10.0-M1", "0.9.3"));
+			new NativeBuildtoolsRange("[0.9.0,0.10.0-M1)", null),
+			new NativeBuildtoolsRange("[0.10.0-M1, 0.11.0-M2)", "0.9.3"),
+			new NativeBuildtoolsRange("[0.11.0-M2,0.11.0-SNAPSHOT)", "0.9.5"));
 
 	static String resolve(String springNativeVersion) {
 		Version nativeVersion = VersionParser.DEFAULT.parse(springNativeVersion);

--- a/start-site/src/main/java/io/spring/start/site/extension/dependency/springnative/SpringNativeGroovyDslGradleBuildCustomizer.java
+++ b/start-site/src/main/java/io/spring/start/site/extension/dependency/springnative/SpringNativeGroovyDslGradleBuildCustomizer.java
@@ -34,7 +34,9 @@ import io.spring.initializr.generator.version.VersionReference;
  */
 class SpringNativeGroovyDslGradleBuildCustomizer extends SpringNativeGradleBuildCustomizer {
 
-	private static final VersionRange NATIVE_0_11 = VersionParser.DEFAULT.parseRange("0.11.0-M1");
+	private static final VersionRange NATIVE_0_11_M1 = VersionParser.DEFAULT.parseRange("0.11.0-M1");
+
+	private static final VersionRange NATIVE_0_11_M2 = VersionParser.DEFAULT.parseRange("[0.11.0-M2,0.11.0-SNAPSHOT)");
 
 	private final Supplier<VersionReference> hibernateVersion;
 
@@ -45,10 +47,10 @@ class SpringNativeGroovyDslGradleBuildCustomizer extends SpringNativeGradleBuild
 	@Override
 	protected void customize(GradleBuild build, String springNativeVersion) {
 		// Native buildtools plugin
+		Version springNative = VersionParser.DEFAULT.parse(springNativeVersion);
 		String nativeBuildtoolsVersion = SpringNativeBuildtoolsVersionResolver.resolve(springNativeVersion);
-		if (nativeBuildtoolsVersion != null) {
-			customizeNativeBuildToolsPlugin(build, VersionParser.DEFAULT.parse(springNativeVersion),
-					nativeBuildtoolsVersion);
+		if (nativeBuildtoolsVersion != null && !NATIVE_0_11_M2.match(springNative)) {
+			customizeNativeBuildToolsPlugin(build, springNative, nativeBuildtoolsVersion);
 		}
 
 		// Hibernate enhance plugin
@@ -72,7 +74,7 @@ class SpringNativeGroovyDslGradleBuildCustomizer extends SpringNativeGradleBuild
 		build.plugins().add("org.graalvm.buildtools.native", (plugin) -> plugin.setVersion(nativeBuildtoolsVersion));
 		build.tasks().customize("nativeBuild",
 				(task) -> task.invoke("classpath", "processAotResources.outputs", "compileAotJava.outputs"));
-		if (!NATIVE_0_11.match(springNativeVersion)) {
+		if (!NATIVE_0_11_M1.match(springNativeVersion)) {
 			build.tasks().customize("nativeTest", (task) -> task.invoke("classpath", "processAotTestResources.outputs",
 					"compileAotTestJava.outputs"));
 		}

--- a/start-site/src/test/java/io/spring/start/site/extension/dependency/springnative/SpringNativeGroovyDslGradleBuildCustomizerTests.java
+++ b/start-site/src/test/java/io/spring/start/site/extension/dependency/springnative/SpringNativeGroovyDslGradleBuildCustomizerTests.java
@@ -96,6 +96,19 @@ public class SpringNativeGroovyDslGradleBuildCustomizerTests extends SpringNativ
 	}
 
 	@Test
+	void gradleBuildWithNative011SnapshotDoesNotAddNativeBuildToolsPlugin() {
+		SpringNativeGradleBuildCustomizer customizer = createCustomizer();
+		GradleBuild build = createBuild("0.11.0-SNAPSHOT");
+		customizer.customize(build);
+		GradlePlugin springAotPlugin = build.plugins().values()
+				.filter((plugin) -> plugin.getId().equals("org.graalvm.buildtools.native")).findAny().orElse(null);
+		assertThat(springAotPlugin).isNull();
+		assertThat(build.tasks().has("nativeCompile")).isFalse();
+		assertThat(build.tasks().has("nativeBuild")).isFalse();
+		assertThat(build.tasks().has("nativeTest")).isFalse();
+	}
+
+	@Test
 	@Override
 	void gradleBuildCustomizeSpringBootPlugin() {
 		SpringNativeGradleBuildCustomizer customizer = createCustomizer();


### PR DESCRIPTION
Prior to this commit, the GraalVM Native Gradle plugin would be added
and configured automatically for applications requiring the Spring
Native dependency.

After Spring Native 0.11.0-M1, this plugin is automatically added and
configured by the AOT plugin so additional customization is not needed
anymore.

<!--
Thanks for contributing to start.spring.io Please review the following notes before
submitting you pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Proposal for New Entries

STOP! If your contribution suggests the addition of a new entry, please do not submit it
Rather create a "New Entry Proposal" issue as we need some information from you before
proceeding.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
