### PR TITLE
Increase MyBatis Spring Boot Starter compatibility range

### DIFF
--- a/start-site/src/main/resources/application.yml
+++ b/start-site/src/main/resources/application.yml
@@ -515,7 +515,7 @@ initializr:
               description: R2DBC Homepage
         - name: MyBatis Framework
           id: mybatis
-          compatibilityRange: "[2.0.0.RELEASE,2.6.0-M1)"
+          compatibilityRange: "[2.0.0.RELEASE,2.7.0-M1)"
           description: Persistence framework with support for custom SQL, stored procedures and advanced mappings. MyBatis couples objects with stored procedures or SQL statements using a XML descriptor or annotations.
           links:
             - rel: guide


### PR DESCRIPTION
I've confirmed compatibility with Spring Boot 2.6 and mybatis-spring-boot 2.2.x and switch base line to Spring Boot 2.6.x on development branch.

* https://github.com/mybatis/spring-boot-starter/issues/591
* https://github.com/kazuki43zoo/mybatis-spring-boot-dev-compatibility-checker

Note: The MyBatis Team will be maintenance to following two lines.

* 2.2.x : for Spring Boot 2.5+ user
* 2.1.x : for Spring Boot 2.4 or under user
