### PR TITLE
Upgrade to Vaadin 14.7.7

### DIFF
--- a/start-site/src/main/resources/application.yml
+++ b/start-site/src/main/resources/application.yml
@@ -141,7 +141,7 @@ initializr:
         versionProperty: vaadin.version
         mappings:
           - compatibilityRange: "[2.1.0.RELEASE,2.6.0-M1)"
-            version: 14.7.5
+            version: 14.7.7
       wavefront:
         groupId: com.wavefront
         artifactId: wavefront-spring-boot-bom


### PR DESCRIPTION
with this version, vaadin is compatible with spring boot 2.6.x

let us have a separate PR for the compatibility range discussion.

