### PR TITLE
Upgrade to MyBatis Spring 2.2.1

### DIFF
--- a/start-site/src/main/resources/application.yml
+++ b/start-site/src/main/resources/application.yml
@@ -542,7 +542,7 @@ initializr:
             - compatibilityRange: "[2.1.0.RELEASE,2.5.0-M1)"
               version: 2.1.4
             - compatibilityRange: "2.5.0-M1"
-              version: 2.2.0
+              version: 2.2.1
         - name: Liquibase Migration
           id: liquibase
           description: Liquibase database migration and source control library.


### PR DESCRIPTION
The mybatis-spring-boot 2.2.1(switch baseline to spring-boot 2.6.x) has been released at today. (We tests it using Spring Boot 2.2.x, 2.3.x, 2.4.x and 2.5.x on GitHub Action).

* https://github.com/mybatis/spring-boot-starter/releases/tag/mybatis-spring-boot-2.2.1