### PR TITLE
Expand compatibility range for MyBatis

### DIFF
--- a/start-site/src/main/resources/application.yml
+++ b/start-site/src/main/resources/application.yml
@@ -528,7 +528,7 @@ initializr:
               description: R2DBC Homepage
         - name: MyBatis Framework
           id: mybatis
-          compatibilityRange: "[2.0.0.RELEASE,2.7.0-M1)"
+          compatibilityRange: "[2.0.0.RELEASE,3.0.0-M1)"
           description: Persistence framework with support for custom SQL, stored procedures and advanced mappings. MyBatis couples objects with stored procedures or SQL statements using a XML descriptor or annotations.
           links:
             - rel: guide


### PR DESCRIPTION
The MyBatis Spring works in Spring Boot 2.7. We tests using Spring Boot 2.7.0-SNAPSHOT at daily build on GitHub Action.

* https://github.com/kazuki43zoo/mybatis-spring-boot-dev-compatibility-checker