### PR TITLE
Upgrade to Spring Cloud GCP 3.1.0 and 2.0.8

### DIFF
--- a/start-site/src/main/resources/application.yml
+++ b/start-site/src/main/resources/application.yml
@@ -107,9 +107,9 @@ initializr:
         additionalBoms: [ spring-cloud ]
         mappings:
           - compatibilityRange: "[2.4.0-M1,2.6.0-M1)"
-            version: 2.0.7
+            version: 2.0.8
           - compatibilityRange: "[2.6.0-M1,2.7.0-M1)"
-            version: 3.0.0
+            version: 3.1.0
       spring-cloud-services:
         groupId: io.pivotal.spring.cloud
         artifactId: spring-cloud-services-dependencies


### PR DESCRIPTION
Spring Cloud GCP 2.0.8 and 3.1.0 were released today.