### PR TITLE
Upgrade to MyBatis Spring 2.2.2

### DIFF
--- a/start-site/src/main/resources/application.yml
+++ b/start-site/src/main/resources/application.yml
@@ -565,7 +565,7 @@ initializr:
             - compatibilityRange: "[2.1.0.RELEASE,2.5.0-M1)"
               version: 2.1.4
             - compatibilityRange: "2.5.0-M1"
-              version: 2.2.1
+              version: 2.2.2
         - name: Liquibase Migration
           id: liquibase
           description: Liquibase database migration and source control library.


### PR DESCRIPTION
The mybatis-spring-boot 2.2.2(applied some changes for supporting spring-native) has been released at today.

* https://github.com/mybatis/spring-boot-starter/releases/tag/mybatis-spring-boot-2.2.2