### PR TITLE
Add tomcat-embed-programmatic dependency when web and native are selected

### DIFF
--- a/start-site/src/main/java/io/spring/start/site/extension/dependency/DependencyProjectGenerationConfiguration.java
+++ b/start-site/src/main/java/io/spring/start/site/extension/dependency/DependencyProjectGenerationConfiguration.java
@@ -31,6 +31,7 @@ import io.spring.start.site.extension.dependency.okta.OktaHelpDocumentCustomizer
 import io.spring.start.site.extension.dependency.reactor.ReactorTestBuildCustomizer;
 import io.spring.start.site.extension.dependency.springbatch.SpringBatchTestBuildCustomizer;
 import io.spring.start.site.extension.dependency.springkafka.SpringKafkaBuildCustomizer;
+import io.spring.start.site.extension.dependency.springnative.SpringNativeBuildCustomizer;
 import io.spring.start.site.extension.dependency.springsecurity.SpringSecurityRSocketBuildCustomizer;
 import io.spring.start.site.extension.dependency.springsecurity.SpringSecurityTestBuildCustomizer;
 import io.spring.start.site.extension.dependency.springsession.SpringSessionBuildCustomizer;
@@ -125,6 +126,12 @@ public class DependencyProjectGenerationConfiguration {
 	@ConditionalOnRequestedDependency("okta")
 	public OktaHelpDocumentCustomizer oktaHelpDocumentCustomizer(MustacheTemplateRenderer templateRenderer) {
 		return new OktaHelpDocumentCustomizer(templateRenderer);
+	}
+
+	@Bean
+	@ConditionalOnRequestedDependency("native")
+	public SpringNativeBuildCustomizer nativeBuildCustomizer() {
+		return new SpringNativeBuildCustomizer();
 	}
 
 }

--- a/start-site/src/main/java/io/spring/start/site/extension/dependency/springnative/SpringNativeBuildCustomizer.java
+++ b/start-site/src/main/java/io/spring/start/site/extension/dependency/springnative/SpringNativeBuildCustomizer.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2012-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.spring.start.site.extension.dependency.springnative;
+
+import io.spring.initializr.generator.buildsystem.Build;
+import io.spring.initializr.generator.buildsystem.Dependency;
+import io.spring.initializr.generator.spring.build.BuildCustomizer;
+import io.spring.initializr.generator.version.VersionReference;
+
+/**
+ * A {@link BuildCustomizer} that provides Tomcat's Embed Programmatic support when both
+ * Spring Web and Spring Native are selected.
+ *
+ * @author Eddú Meléndez
+ */
+public class SpringNativeBuildCustomizer implements BuildCustomizer<Build> {
+
+	@Override
+	public void customize(Build build) {
+		if (build.dependencies().has("web") && build.dependencies().has("native")) {
+			build.dependencies().add("tomcat-embed-programmatic",
+					Dependency.withCoordinates("org.apache.tomcat.experimental", "tomcat-embed-programmatic")
+							.version(VersionReference.ofProperty("tomcat.version")));
+		}
+	}
+
+}

--- a/start-site/src/test/java/io/spring/start/site/extension/dependency/springnative/SpringNativeBuildCustomizerTest.java
+++ b/start-site/src/test/java/io/spring/start/site/extension/dependency/springnative/SpringNativeBuildCustomizerTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2012-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.spring.start.site.extension.dependency.springnative;
+
+import io.spring.initializr.metadata.Dependency;
+import io.spring.initializr.web.project.ProjectRequest;
+import io.spring.start.site.extension.AbstractExtensionTests;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link SpringNativeBuildCustomizer}.
+ *
+ * @author Eddú Meléndez
+ */
+class SpringNativeBuildCustomizerTest extends AbstractExtensionTests {
+
+	@Test
+	void tomcatEmbedProgrammaticIsAdded() {
+		ProjectRequest request = createProjectRequest("web", "native");
+		Dependency tomcatEmbedProgrammatic = Dependency.withId("tomcat-embed-programmatic",
+				"org.apache.tomcat.experimental", "tomcat-embed-programmatic", "${tomcat.version}");
+		assertThat(mavenPom(request)).hasDependency(tomcatEmbedProgrammatic).hasDependenciesSize(4);
+	}
+
+	@Test
+	void tomcatEmbedProgrammaticIsNotAddedWithoutWeb() {
+		ProjectRequest request = createProjectRequest("webflux", "native");
+		assertThat(mavenPom(request)).hasDependency(Dependency.createSpringBootStarter("webflux"))
+				.hasDependency(Dependency.createSpringBootStarter("test", Dependency.SCOPE_TEST))
+				.hasDependenciesSize(4);
+	}
+
+	@Test
+	void tomcatEmbedProgrammaticIsNotAddedWithoutNative() {
+		ProjectRequest request = createProjectRequest("web");
+		assertThat(mavenPom(request)).hasDependency(Dependency.createSpringBootStarter("web"))
+				.hasDependency(Dependency.createSpringBootStarter("test", Dependency.SCOPE_TEST))
+				.hasDependenciesSize(2);
+	}
+
+}


### PR DESCRIPTION
Spring Native documentation mention:
> org.apache.tomcat.experimental:tomcat-embed-programmatic dependency should be used for optimized footprint.
