### PR TITLE
Add support for Vaadin 23.0.0

### DIFF
--- a/start-site/src/main/resources/application.yml
+++ b/start-site/src/main/resources/application.yml
@@ -156,9 +156,9 @@ initializr:
         artifactId: vaadin-bom
         versionProperty: vaadin.version
         mappings:
-          - compatibilityRange: "[2.1.0.RELEASE,2.8.0-M1)"
+          - compatibilityRange: "[2.1.0.RELEASE,2.6.0-M1)"
             version: 14.8.4
-          - compatibilityRange: "[2.6.4,2.8.0-M1)"
+          - compatibilityRange: "[2.6.0,2.8.0-M1)"
             version: 23.0.0
       wavefront:
         groupId: com.wavefront

--- a/start-site/src/main/resources/application.yml
+++ b/start-site/src/main/resources/application.yml
@@ -158,6 +158,8 @@ initializr:
         mappings:
           - compatibilityRange: "[2.1.0.RELEASE,2.8.0-M1)"
             version: 14.8.4
+          - compatibilityRange: "[2.6.4,2.8.0-M1)"
+            version: 23.0.0
       wavefront:
         groupId: com.wavefront
         artifactId: wavefront-spring-boot-bom


### PR DESCRIPTION
We will release Vaadin 23.0.0 today, which is the latest LTS version by us. 
and at the same time, V14 is still supported until 2023(roughly)

I am a bit uncertain whether the compatibility range can be overlapped between different versions, 
so please let me know if this is doable, thanks

<!--
Thanks for contributing to start.spring.io Please review the following notes before
submitting you pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Proposal for New Entries

STOP! If your contribution suggests the addition of a new entry, please do not submit it
Rather create a "New Entry Proposal" issue as we need some information from you before
proceeding.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
