### PR TITLE
Adding Amazon Web Services (AWS) back

### DIFF
--- a/start-site/src/main/java/io/spring/start/site/extension/dependency/springcloud/SpringCloudFunctionHelpDocumentCustomizer.java
+++ b/start-site/src/main/java/io/spring/start/site/extension/dependency/springcloud/SpringCloudFunctionHelpDocumentCustomizer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2021 the original author or authors.
+ * Copyright 2012-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -129,7 +129,8 @@ class SpringCloudFunctionHelpDocumentCustomizer implements HelpDocumentCustomize
 	 */
 	enum CloudPlatform {
 
-		AZURE("Microsoft Azure", "azure-support", Collections.singletonList(MavenBuildSystem.ID));
+		AWS("AWS Lambda", "cloud-aws"), AZURE("Microsoft Azure", "azure-support",
+				Collections.singletonList(MavenBuildSystem.ID));
 
 		private final String name;
 

--- a/start-site/src/main/resources/application.yml
+++ b/start-site/src/main/resources/application.yml
@@ -124,7 +124,7 @@ initializr:
           - compatibilityRange: "[2.4.0-M1,2.5.0-M1)"
             version: 2.4.1
           - compatibilityRange: "[2.5.0-M1,2.6.0-M1)"
-            version: 3.3.0          
+            version: 3.3.0
           - compatibilityRange: "[2.6.0-M1,2.7.0-M1)"
             version: 3.4.0
       spring-geode:
@@ -1371,6 +1371,57 @@ initializr:
           links:
             - rel: reference
               href: https://docs.pivotal.io/spring-cloud-services/
+    - name: Amazon Web Services
+      compatibilityRange: "[2.4.0,2.7.0-M1)"
+      content:
+        - name: AWS Core
+          id: cloud-aws
+          description: Core module of Spring Cloud AWS providing basic services for security and configuration setup.
+          groupId: io.awspring.cloud
+          artifactId: spring-cloud-starter-aws
+          links:
+            - rel: reference
+              href: https://docs.awspring.io/spring-cloud-aws/docs/current/reference/html/index.html
+        - name: Amazon Relation Database Service (RDS)
+          id: cloud-aws-jdbc
+          description: Relational databases on AWS with RDS and Spring Cloud AWS JDBC.
+          groupId: io.awspring.cloud
+          artifactId: spring-cloud-starter-aws-jdbc
+          links:
+            - rel: reference
+              href: https://docs.awspring.io/spring-cloud-aws/docs/current/reference/html/index.html#data-access-with-jdbc
+        - name: AWS Messaging - Simple Queue Service (SQS) and Simple Notification Service (SNS)
+          id: cloud-aws-messaging
+          description: Messaging on AWS with SQS/ SNS and Spring Cloud AWS Messaging.
+          groupId: io.awspring.cloud
+          artifactId: spring-cloud-starter-aws-messaging
+          links:
+            - rel: reference
+              href: https://docs.awspring.io/spring-cloud-aws/docs/current/reference/html/index.html#messaging
+        - name: AWS Parameter Store
+          id: cloud-aws-parameter-store-config
+          description: Enables Spring Cloud applications to use the AWS Parameter Store as a Bootstrap Property Source.
+          groupId: io.awspring.cloud
+          artifactId: spring-cloud-starter-aws-parameter-store-config
+          links:
+            - rel: reference
+              href: https://docs.awspring.io/spring-cloud-aws/docs/current/reference/html/index.html#integrating-your-spring-cloud-application-with-the-aws-parameter-store
+        - name: AWS Secrets Manager
+          id: cloud-aws-secrets-manager-config
+          description: Enables Spring Cloud applications to use the AWS Secrets Manager as a Bootstrap Property Source.
+          groupId: io.awspring.cloud
+          artifactId: spring-cloud-starter-aws-secrets-manager-config
+          links:
+            - rel: reference
+              href: https://docs.awspring.io/spring-cloud-aws/docs/current/reference/html/index.html#integrating-your-spring-cloud-application-with-the-aws-secrets-manager
+        - name: Amazon Simple Email Service (SES)
+          id: cloud-aws-ses
+          description: Supports Amazon SES as an implementation of the Spring Mail abstraction.
+          groupId: io.awspring.cloud
+          artifactId: spring-cloud-starter-aws-ses
+          links:
+            - rel: reference
+              href: https://docs.awspring.io/spring-cloud-aws/docs/current/reference/html/index.html#sending-mails
     - name: Microsoft Azure
       bom: azure
       compatibilityRange: "[2.2.11.RELEASE,2.7.0-M1)"

--- a/start-site/src/main/resources/templates/spring-cloud-function-build-setup-aws.mustache
+++ b/start-site/src/main/resources/templates/spring-cloud-function-build-setup-aws.mustache
@@ -1,0 +1,8 @@
+## Running Spring Cloud Function applications on {{platform}}
+
+In order to run Spring Cloud Function applications on AWS Lambda, you can leverage Spring Cloud
+Function AWS adapter and {{buildTool}} plugins offered by {{platform}}.
+
+Check the documentation for detailed information on [using the AWS Lambda adapter](https://cloud.spring.io/spring-cloud-static/spring-cloud-function/{{version}}/aws.html)
+and [setting up the {{buildTool}} build, along with a full build setup sample](https://cloud.spring.io/spring-cloud-static/spring-cloud-function/{{version}}/aws.html#_build_file_setup).
+


### PR DESCRIPTION
I noticed the AWS dependencies had been removed as part of commit cd6d17b1 as Spring Boot 2.3.x is EOL. This had already been reported in #783. Newer versions supporting Spring Boot >2.3.x are available but the groupId changed.

