### PR TITLE
Upgrade to Spring Cloud GCP 2.0.9 and 3.2.0

### DIFF
--- a/start-site/src/main/resources/application.yml
+++ b/start-site/src/main/resources/application.yml
@@ -110,9 +110,9 @@ initializr:
         additionalBoms: [ spring-cloud ]
         mappings:
           - compatibilityRange: "[2.4.0-M1,2.6.0-M1)"
-            version: 2.0.8
+            version: 2.0.9
           - compatibilityRange: "[2.6.0-M1,2.7.0-M1)"
-            version: 3.1.0
+            version: 3.2.0
       spring-cloud-services:
         groupId: io.pivotal.spring.cloud
         artifactId: spring-cloud-services-dependencies


### PR DESCRIPTION
We've released Spring Cloud GCP 2.0.9 and 3.2.0.