### PR TITLE
Rename "Spring GraphQL" to "Spring for GraphQL".

### DIFF
--- a/start-site/src/main/resources/application.yml
+++ b/start-site/src/main/resources/application.yml
@@ -330,9 +330,9 @@ initializr:
               description: Building a Reactive RESTful Web Service
             - rel: reference
               href: https://docs.spring.io/spring-boot/docs/{bootVersion}/reference/htmlsingle/#web.reactive
-        - name: Spring GraphQL
+        - name: Spring for GraphQL
           id: graphql
-          description: Build GraphQL applications with Spring GraphQL and GraphQL Java.
+          description: Build GraphQL applications with Spring for GraphQL and GraphQL Java.
           facets:
             - json
           compatibilityRange: "[2.7.0.M1,3.0.0-M1)"


### PR DESCRIPTION
Spring GraphQL has been renamed to Spring for GraphQL to follow trademark guidelines (https://github.com/spring-projects/spring-graphql/issues/376).

This PR fixes start.spring.io to show the new name that does not violate trademark guidelines.