### PR TITLE
Add flyway dependencies for mariadb, mysql, sqlserver

### DIFF
--- a/start-site/src/main/java/io/spring/start/site/extension/dependency/DependencyProjectGenerationConfiguration.java
+++ b/start-site/src/main/java/io/spring/start/site/extension/dependency/DependencyProjectGenerationConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2021 the original author or authors.
+ * Copyright 2012-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,9 +20,11 @@ import io.spring.initializr.generator.buildsystem.gradle.GradleBuildSystem;
 import io.spring.initializr.generator.condition.ConditionalOnBuildSystem;
 import io.spring.initializr.generator.condition.ConditionalOnRequestedDependency;
 import io.spring.initializr.generator.io.template.MustacheTemplateRenderer;
+import io.spring.initializr.generator.project.ProjectDescription;
 import io.spring.initializr.generator.project.ProjectGenerationConfiguration;
 import io.spring.initializr.generator.spring.build.gradle.ConditionalOnGradleVersion;
 import io.spring.initializr.metadata.InitializrMetadata;
+import io.spring.start.site.extension.dependency.flyway.FlywayBuildCustomizer;
 import io.spring.start.site.extension.dependency.flyway.FlywayProjectContributor;
 import io.spring.start.site.extension.dependency.graphql.SpringGraphQlBuildCustomizer;
 import io.spring.start.site.extension.dependency.liquibase.LiquibaseProjectContributor;
@@ -125,6 +127,12 @@ public class DependencyProjectGenerationConfiguration {
 	@ConditionalOnRequestedDependency("okta")
 	public OktaHelpDocumentCustomizer oktaHelpDocumentCustomizer(MustacheTemplateRenderer templateRenderer) {
 		return new OktaHelpDocumentCustomizer(templateRenderer);
+	}
+
+	@Bean
+	@ConditionalOnRequestedDependency("flyway")
+	public FlywayBuildCustomizer flywayBuildCustomizer(ProjectDescription projectDescription) {
+		return new FlywayBuildCustomizer(projectDescription);
 	}
 
 }

--- a/start-site/src/main/java/io/spring/start/site/extension/dependency/flyway/FlywayBuildCustomizer.java
+++ b/start-site/src/main/java/io/spring/start/site/extension/dependency/flyway/FlywayBuildCustomizer.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2012-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.spring.start.site.extension.dependency.flyway;
+
+import io.spring.initializr.generator.buildsystem.Build;
+import io.spring.initializr.generator.buildsystem.DependencyContainer;
+import io.spring.initializr.generator.buildsystem.DependencyScope;
+import io.spring.initializr.generator.project.ProjectDescription;
+import io.spring.initializr.generator.spring.build.BuildCustomizer;
+import io.spring.initializr.generator.version.VersionParser;
+import io.spring.initializr.generator.version.VersionRange;
+
+/**
+ * Determine the appropriate Flyway dependency according to the database.
+ *
+ * @author Eddú Meléndez
+ */
+public class FlywayBuildCustomizer implements BuildCustomizer<Build> {
+
+	private static final VersionRange SPRING_BOOT_2_7_0_OR_LATER = VersionParser.DEFAULT.parseRange("2.7.0");
+
+	private final ProjectDescription projectDescription;
+
+	public FlywayBuildCustomizer(ProjectDescription projectDescription) {
+		this.projectDescription = projectDescription;
+	}
+
+	@Override
+	public void customize(Build build) {
+		if (SPRING_BOOT_2_7_0_OR_LATER.match(this.projectDescription.getPlatformVersion())) {
+			DependencyContainer dependencies = build.dependencies();
+			if ((dependencies.has("mysql") || dependencies.has("mariadb")) && dependencies.has("flyway")) {
+				dependencies.add("flyway-mysql", "org.flywaydb", "flyway-mysql", DependencyScope.COMPILE);
+			}
+			if (dependencies.has("sqlserver") && dependencies.has("flyway")) {
+				dependencies.add("flyway-sqlserver", "org.flywaydb", "flyway-sqlserver", DependencyScope.COMPILE);
+			}
+		}
+	}
+
+}

--- a/start-site/src/test/java/io/spring/start/site/extension/dependency/flyway/FlywayBuildCustomizerTests.java
+++ b/start-site/src/test/java/io/spring/start/site/extension/dependency/flyway/FlywayBuildCustomizerTests.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2012-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.spring.start.site.extension.dependency.flyway;
+
+import io.spring.initializr.web.project.ProjectRequest;
+import io.spring.start.site.extension.AbstractExtensionTests;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link FlywayBuildCustomizer}.
+ *
+ * @author Eddú Meléndez
+ */
+class FlywayBuildCustomizerTest extends AbstractExtensionTests {
+
+	@Test
+	void mariadbOnly() {
+		ProjectRequest projectRequest = createProject("2.7.0", "mariadb");
+		assertThat(mavenPom(projectRequest)).hasDependency(getDependency("mariadb"))
+				.doesNotHaveDependency("org.flywaydb", "flyway-mysql");
+	}
+
+	@Test
+	void mysqlOnly() {
+		ProjectRequest projectRequest = createProject("2.7.0", "mysql");
+		assertThat(mavenPom(projectRequest)).hasDependency(getDependency("mysql")).doesNotHaveDependency("org.flywaydb",
+				"flyway-mysql");
+	}
+
+	@Test
+	void sqlserverOnly() {
+		ProjectRequest projectRequest = createProject("2.7.0", "sqlserver");
+		assertThat(mavenPom(projectRequest)).hasDependency(getDependency("sqlserver"))
+				.doesNotHaveDependency("org.flywaydb", "flyway-sqlserver");
+	}
+
+	@Test
+	void mariadbAndFlywayPreviousTo270() {
+		ProjectRequest projectRequest = createProject("2.6.0", "mariadb", "flyway");
+		assertThat(mavenPom(projectRequest)).hasDependency(getDependency("mariadb"))
+				.doesNotHaveDependency("org.flywaydb", "flyway-mysql");
+	}
+
+	@Test
+	void mysqlAndFlywayPreviousTo270() {
+		ProjectRequest projectRequest = createProject("2.6.0", "mysql", "flyway");
+		assertThat(mavenPom(projectRequest)).hasDependency(getDependency("mysql")).doesNotHaveDependency("org.flywaydb",
+				"flyway-mysql");
+	}
+
+	@Test
+	void sqlserverAndFlywayPreviousTo270() {
+		ProjectRequest projectRequest = createProject("2.6.0", "sqlserver", "flyway");
+		assertThat(mavenPom(projectRequest)).hasDependency(getDependency("sqlserver"))
+				.doesNotHaveDependency("org.flywaydb", "flyway-sqlserver");
+	}
+
+	@Test
+	void mariadbAndFlyway() {
+		ProjectRequest projectRequest = createProject("2.7.0", "mariadb", "flyway");
+		assertThat(mavenPom(projectRequest)).hasDependency(getDependency("mariadb")).hasDependency("org.flywaydb",
+				"flyway-mysql");
+	}
+
+	@Test
+	void mysqlAndFlyway() {
+		ProjectRequest projectRequest = createProject("2.7.0", "mysql", "flyway");
+		assertThat(mavenPom(projectRequest)).hasDependency(getDependency("mysql")).hasDependency("org.flywaydb",
+				"flyway-mysql");
+	}
+
+	@Test
+	void sqlserverAndFlyway() {
+		ProjectRequest projectRequest = createProject("2.7.0", "sqlserver", "flyway");
+		assertThat(mavenPom(projectRequest)).hasDependency(getDependency("sqlserver")).hasDependency("org.flywaydb",
+				"flyway-sqlserver");
+	}
+
+	private ProjectRequest createProject(String springBootVersion, String... styles) {
+		ProjectRequest projectRequest = createProjectRequest(styles);
+		projectRequest.setLanguage("java");
+		projectRequest.setJavaVersion("11");
+		projectRequest.setBootVersion(springBootVersion);
+		return projectRequest;
+	}
+
+}


### PR DESCRIPTION
Spring Boot 2.7.x provides dependencies for `flyway-core`,
`flyway-mysql` and `flyway-sqlserver` which are needed when
flyway and the database driver are present.
