### PR TITLE
Moved goal prepare-frontend of the Vaadin plugin to the build

### DIFF
--- a/start-site/src/main/java/io/spring/start/site/extension/dependency/vaadin/VaadinMavenBuildCustomizer.java
+++ b/start-site/src/main/java/io/spring/start/site/extension/dependency/vaadin/VaadinMavenBuildCustomizer.java
@@ -29,9 +29,12 @@ class VaadinMavenBuildCustomizer implements BuildCustomizer<MavenBuild> {
 
 	@Override
 	public void customize(MavenBuild build) {
+		build.plugins().add("com.vaadin", "vaadin-maven-plugin", (plugin) -> plugin.version("${vaadin.version}")
+				.execution("prepare-frontend", (execution) -> execution.goal("prepare-frontend")));
+
 		build.profiles().id("production").plugins().add("com.vaadin", "vaadin-maven-plugin",
 				(plugin) -> plugin.version("${vaadin.version}").execution("frontend",
-						(execution) -> execution.goal("prepare-frontend").goal("build-frontend").phase("compile")
+						(execution) -> execution.goal("build-frontend").phase("compile")
 								.configuration((configuration) -> configuration.add("productionMode", "true"))));
 	}
 

--- a/start-site/src/test/java/io/spring/start/site/extension/dependency/vaadin/VaadinProjectGenerationConfigurationTests.java
+++ b/start-site/src/test/java/io/spring/start/site/extension/dependency/vaadin/VaadinProjectGenerationConfigurationTests.java
@@ -42,7 +42,6 @@ class VaadinProjectGenerationConfigurationTests extends AbstractExtensionTests {
 						"								<id>frontend</id>",
 						"								<phase>compile</phase>",
 						"								<goals>",
-						"									<goal>prepare-frontend</goal>",
 						"									<goal>build-frontend</goal>",
 						"								</goals>", "								<configuration>",
 						"									<productionMode>true</productionMode>",


### PR DESCRIPTION
The goal prepare-frontend must run with the build no matter which profile is activated to make the Vaaddin application run otherwise the Vaadin application does not start.