### PR TITLE
Add testcontainers consul and vault modules

### DIFF
--- a/start-site/src/main/java/io/spring/start/site/extension/dependency/testcontainers/TestcontainersModuleRegistry.java
+++ b/start-site/src/main/java/io/spring/start/site/extension/dependency/testcontainers/TestcontainersModuleRegistry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2021 the original author or authors.
+ * Copyright 2012-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/start-site/src/main/java/io/spring/start/site/extension/dependency/testcontainers/TestcontainersModuleRegistry.java
+++ b/start-site/src/main/java/io/spring/start/site/extension/dependency/testcontainers/TestcontainersModuleRegistry.java
@@ -32,6 +32,7 @@ import io.spring.start.site.support.implicit.ImplicitDependency.Builder;
  * A registry of available Testcontainers modules.
  *
  * @author Stephane Nicoll
+ * @author Eddú Meléndez
  */
 abstract class TestcontainersModuleRegistry {
 
@@ -39,6 +40,10 @@ abstract class TestcontainersModuleRegistry {
 		return create(
 				onDependencies("amqp").customizeBuild(addModule("rabbitmq"))
 						.customizeHelpDocument(addReferenceLink("RabbitMQ Module", "rabbitmq/")),
+				onDependencies("cloud-starter-consul-config").customizeBuild(addModule("consul"))
+						.customizeHelpDocument(addReferenceLink("Consul Module", "consul/")),
+				onDependencies("cloud-starter-vault-config").customizeBuild(addModule("vault"))
+						.customizeHelpDocument(addReferenceLink("Vault Module", "vault/")),
 				onDependencies("data-cassandra", "data-cassandra-reactive").customizeBuild(addModule("cassandra"))
 						.customizeHelpDocument(addReferenceLink("Cassandra Module", "databases/cassandra/")),
 				onDependencies("data-couchbase", "data-couchbase-reactive").customizeBuild(addModule("couchbase"))

--- a/start-site/src/test/java/io/spring/start/site/extension/dependency/testcontainers/TestcontainersProjectGenerationConfigurationTests.java
+++ b/start-site/src/test/java/io/spring/start/site/extension/dependency/testcontainers/TestcontainersProjectGenerationConfigurationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2021 the original author or authors.
+ * Copyright 2012-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/start-site/src/test/java/io/spring/start/site/extension/dependency/testcontainers/TestcontainersProjectGenerationConfigurationTests.java
+++ b/start-site/src/test/java/io/spring/start/site/extension/dependency/testcontainers/TestcontainersProjectGenerationConfigurationTests.java
@@ -34,6 +34,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  *
  * @author Maciej Walkowiak
  * @author Stephane Nicoll
+ * @author Eddú Meléndez
  */
 class TestcontainersProjectGenerationConfigurationTests extends AbstractExtensionTests {
 
@@ -83,6 +84,8 @@ class TestcontainersProjectGenerationConfigurationTests extends AbstractExtensio
 
 	static Stream<Arguments> supportedEntriesHelpDocument() {
 		return Stream.of(Arguments.arguments("amqp", "rabbitmq/"),
+				Arguments.arguments("cloud-starter-consul-config", "consul/"),
+				Arguments.arguments("cloud-starter-vault-config", "vault/"),
 				Arguments.arguments("data-cassandra", "databases/cassandra/"),
 				Arguments.arguments("data-cassandra-reactive", "databases/cassandra/"),
 				Arguments.arguments("data-couchbase", "databases/couchbase/"),


### PR DESCRIPTION
Add testcontainers module when `cloud-starter-consul-config` or
`cloud-starter-vault-config` are selected.
