### PR TITLE
Upgrade to MyBatis Spring 3.0 and 2.3

### DIFF
--- a/start-site/src/main/resources/application.yml
+++ b/start-site/src/main/resources/application.yml
@@ -606,8 +606,10 @@ initializr:
           mappings:
             - compatibilityRange: "[2.1.0.RELEASE,2.5.0-M1)"
               version: 2.1.4
-            - compatibilityRange: "2.5.0-M1"
-              version: 2.2.2
+            - compatibilityRange: "[2.5.0-M1,3.0.0-M1)"
+              version: 2.3.0
+            - compatibilityRange: "3.0.0-M1"
+              version: 3.0.0
         - name: Liquibase Migration
           id: liquibase
           description: Liquibase database migration and source control library.


### PR DESCRIPTION
The mybatis-spring-boot 3.0.0 and 2.3.0 has been released at now.

* https://github.com/mybatis/spring-boot-starter/releases/tag/mybatis-spring-boot-3.0.0
* https://github.com/mybatis/spring-boot-starter/releases/tag/mybatis-spring-boot-2.3.0