### PR TITLE
Update Vaadin docs link

### DIFF
--- a/start-client/dev/api.mock.json
+++ b/start-client/dev/api.mock.json
@@ -174,7 +174,7 @@
                 "href": "https://spring.io/guides/gs/crud-with-vaadin/",
                 "title": "Creating CRUD UI with Vaadin"
               },
-              "reference": { "href": "https://vaadin.com/spring" }
+              "reference": { "href": "https://vaadin.com/docs" }
             }
           }
         ]


### PR DESCRIPTION
The old Vaadin Spring link, https://vaadin.com/spring, is no longer valid. Instead, linking to the main Vaadin docs is more appropriate, as the whole Vaadin documentation is now mostly Spring-based.
