### PR TITLE
Upgrade to Vaadin 23.3.0

### DIFF
--- a/start-site/src/main/resources/application.yml
+++ b/start-site/src/main/resources/application.yml
@@ -172,8 +172,10 @@ initializr:
         mappings:
           - compatibilityRange: "[2.1.0.RELEASE,2.6.0-M1)"
             version: 14.9.2
-          - compatibilityRange: "[2.6.0-M1,2.8.0-M1)"
+          - compatibilityRange: "[2.6.0-M1,2.7.0-M1)"
             version: 23.2.10
+          - compatibilityRange: "[2.7.0-M1,2.8.0-M1)"
+            version: 23.3.0
       wavefront:
         groupId: com.wavefront
         artifactId: wavefront-spring-boot-bom


### PR DESCRIPTION
Added new entry for Vaadin 23.3.0
the supported Spring-boot version in V23.3 is 2.7

