### PR TITLE
Update frontend-maven-plugin 1.12.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -124,7 +124,7 @@
 				<plugin>
 					<groupId>com.github.eirslett</groupId>
 					<artifactId>frontend-maven-plugin</artifactId>
-					<version>1.10.0</version>
+					<version>1.12.1</version>
 				</plugin>
 				<plugin>
 					<artifactId>maven-resources-plugin</artifactId>


### PR DESCRIPTION
Adds support for Mac M1 downloading x86 version of Node. 

Without this update, the project does not build on Mac M1 at all. With this update, the project will download the x86 version of Node `v14.19.3` and M1 user's can set their architecture via Rosetta in order to run and dev locally.

This is a stop-gap solution until #973 is done and Node 16 is used (which does support Arm64 arch). Note that 973 would also require this update as it has the support required for using Node 16 as well.

### Steps to repro
On a Mac M1...
* Delete `start-client/node` and `start-client/node-modules`
* Run `.mvnw clean install`

Fails with: 
```java
[INFO] --- frontend-maven-plugin:1.10.0:install-node-and-yarn (install node and yarn) @ start-client ---
[INFO] Installing node version v14.19.3
[INFO] Downloading https://nodejs.org/dist/v14.19.3/node-v14.19.3-darwin-arm64.tar.gz to /Users/cbono/.m2/repository/com/github/eirslett/node/14.19.3/node-14.19.3-darwin-arm64.tar.gz
[INFO] No proxies configured
[INFO] No proxy was configured, downloading directly
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary for start.spring.io 0.0.1-SNAPSHOT:
[INFO]
[INFO] start.spring.io .................................... SUCCESS [  0.496 s]
[INFO] start.spring.io client ............................. FAILURE [  0.668 s]
[INFO] start.spring.io website ............................ SKIPPED
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  1.307 s
[INFO] Finished at: 2023-03-09T18:05:15-06:00
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal com.github.eirslett:frontend-maven-plugin:1.10.0:install-node-and-yarn (install node and yarn) on project start-client: Could not download Node.js: Got error code 404 from the server. -> [Help 1]
```

### Cause
The `frontend-maven-plugin` uses the arch of the machine to pick the download url for node. The path it uses does not have a match for the M1.  See https://github.com/eirslett/frontend-maven-plugin/issues/952.

### Fix
Update the plugin to `1.12.1`.