### PR TITLE
Upgrade to MyBatis Spring 3.0.1

### DIFF
--- a/start-site/src/main/resources/application.yml
+++ b/start-site/src/main/resources/application.yml
@@ -565,7 +565,7 @@ initializr:
             - compatibilityRange: "[2.7.0-M1,3.0.0-M1)"
               version: 2.3.0
             - compatibilityRange: "3.0.0-M1"
-              version: 3.0.0
+              version: 3.0.1
         - name: Liquibase Migration
           id: liquibase
           description: Liquibase database migration and source control library.


### PR DESCRIPTION
The [mybatis-spring-boot 3.0.1](https://github.com/mybatis/spring-boot-starter/releases/tag/mybatis-spring-boot-3.0.1) already released at 2022-12. This version includes changes for supporting native-image.