### PR TITLE
Enable Vaadin with Spring Boot 3.1.0

### DIFF
--- a/start-site/src/main/resources/application.yml
+++ b/start-site/src/main/resources/application.yml
@@ -188,7 +188,7 @@ initializr:
             version: 23.2.15
           - compatibilityRange: "[2.7.0-M1,3.0.0-M1)"
             version: 23.3.11
-          - compatibilityRange: "[3.0.0-M1,3.1.0-M1)"
+          - compatibilityRange: "[3.0.0-M1,3.2.0-M1)"
             version: 24.0.5
       wavefront:
         groupId: com.wavefront
@@ -376,7 +376,7 @@ initializr:
           artifactId: vaadin-spring-boot-starter
           description: A web framework that allows you to write UI in pure Java without getting bogged down in JS, HTML, and CSS.
           bom: vaadin
-          compatibilityRange: "[2.0.0.RELEASE,3.1.0-M1)"
+          compatibilityRange: "[2.0.0.RELEASE,3.2.0-M1)"
           links:
             - rel: guide
               href: https://spring.io/guides/gs/crud-with-vaadin/


### PR DESCRIPTION
Vaadin 24.0 works fine with Spring Boot 3.1, so this PR increases the compatibility range for it.