### PR TITLE
Support MyBatis testing starter 

### DIFF
--- a/start-site/src/main/java/io/spring/start/site/extension/dependency/DependencyProjectGenerationConfiguration.java
+++ b/start-site/src/main/java/io/spring/start/site/extension/dependency/DependencyProjectGenerationConfiguration.java
@@ -26,6 +26,7 @@ import io.spring.initializr.generator.spring.build.gradle.ConditionalOnGradleVer
 import io.spring.initializr.metadata.InitializrMetadata;
 import io.spring.start.site.extension.dependency.liquibase.LiquibaseProjectContributor;
 import io.spring.start.site.extension.dependency.lombok.LombokGradleBuildCustomizer;
+import io.spring.start.site.extension.dependency.mybatis.MyBatisTestBuildCustomizer;
 import io.spring.start.site.extension.dependency.okta.OktaHelpDocumentCustomizer;
 import io.spring.start.site.extension.dependency.reactor.ReactorTestBuildCustomizer;
 import io.spring.start.site.extension.dependency.springbatch.SpringBatchTestBuildCustomizer;
@@ -44,6 +45,7 @@ import org.springframework.context.annotation.Bean;
  * @author Madhura Bhave
  * @author Stephane Nicoll
  * @author Eddú Meléndez
+ * @author Kazuki Shimizu
  */
 @ProjectGenerationConfiguration
 public class DependencyProjectGenerationConfiguration {
@@ -112,6 +114,12 @@ public class DependencyProjectGenerationConfiguration {
 	@ConditionalOnRequestedDependency("okta")
 	public OktaHelpDocumentCustomizer oktaHelpDocumentCustomizer(MustacheTemplateRenderer templateRenderer) {
 		return new OktaHelpDocumentCustomizer(templateRenderer);
+	}
+
+	@Bean
+	@ConditionalOnRequestedDependency("mybatis")
+	public MyBatisTestBuildCustomizer mybatisTestBuildCustomizer() {
+		return new MyBatisTestBuildCustomizer();
 	}
 
 }

--- a/start-site/src/main/java/io/spring/start/site/extension/dependency/mybatis/MyBatisTestBuildCustomizer.java
+++ b/start-site/src/main/java/io/spring/start/site/extension/dependency/mybatis/MyBatisTestBuildCustomizer.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2012-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.spring.start.site.extension.dependency.mybatis;
+
+import io.spring.initializr.generator.buildsystem.Build;
+import io.spring.initializr.generator.buildsystem.Dependency;
+import io.spring.initializr.generator.buildsystem.DependencyScope;
+import io.spring.initializr.generator.spring.build.BuildCustomizer;
+
+/**
+ * A {@link BuildCustomizer} that automatically adds {@code mybatis-spring-boot-starter-test} when
+ * MyBatis is selected.
+ *
+ * @author Kazuki Shimizu
+ */
+public class MyBatisTestBuildCustomizer implements BuildCustomizer<Build> {
+
+	@Override
+	public void customize(Build build) {
+		Dependency mybatis = build.dependencies().get("mybatis");
+		build.dependencies()
+			.add("mybatis-test", Dependency.withCoordinates(mybatis.getGroupId(), mybatis.getArtifactId() + "-test")
+				.version(mybatis.getVersion())
+				.scope(DependencyScope.TEST_COMPILE));
+	}
+
+}

--- a/start-site/src/main/java/io/spring/start/site/extension/dependency/mybatis/package-info.java
+++ b/start-site/src/main/java/io/spring/start/site/extension/dependency/mybatis/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2012-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Extensions for generation of projects that depend on MyBatis.
+ */
+package io.spring.start.site.extension.dependency.mybatis;

--- a/start-site/src/test/java/io/spring/start/site/extension/dependency/mybatis/MyBatisTestBuildCustomizerTests.java
+++ b/start-site/src/test/java/io/spring/start/site/extension/dependency/mybatis/MyBatisTestBuildCustomizerTests.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2012-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.spring.start.site.extension.dependency.mybatis;
+
+import io.spring.initializr.metadata.Dependency;
+import io.spring.initializr.web.project.ProjectRequest;
+import io.spring.start.site.extension.AbstractExtensionTests;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link MyBatisTestBuildCustomizer}.
+ *
+ * @author Kazuki Shimizu
+ */
+class MyBatisTestBuildCustomizerTests extends AbstractExtensionTests {
+
+	@Test
+	void mybatisIsAddedWithSecurity() {
+		ProjectRequest request = createProjectRequest("mybatis");
+		assertThat(mavenPom(request))
+			.hasDependency(mybatis())
+			.hasDependency(Dependency.createSpringBootStarter("test", Dependency.SCOPE_TEST))
+			.hasDependency(mybatisTest())
+			.hasDependenciesSize(3);
+	}
+
+	@Test
+	void mybatisTestIsNotAddedWithoutMyBatis() {
+		ProjectRequest request = createProjectRequest("web");
+		assertThat(mavenPom(request)).hasDependency(Dependency.createSpringBootStarter("web"))
+			.hasDependency(Dependency.createSpringBootStarter("test", Dependency.SCOPE_TEST))
+			.hasDependenciesSize(2);
+	}
+
+	private static Dependency mybatis() {
+		return Dependency.withId("mybatis", "org.mybatis.spring.boot",
+				"mybatis-spring-boot-starter");
+	}
+
+	private static Dependency mybatisTest() {
+		Dependency dependency = Dependency.withId("mybatis-test", "org.mybatis.spring.boot",
+				"mybatis-spring-boot-starter-test");
+		dependency.setScope(Dependency.SCOPE_TEST);
+		return dependency;
+	}
+
+}


### PR DESCRIPTION
The [mybatis-spring-boot-starter](http://mybatis.org/spring-boot-starter/mybatis-spring-boot-autoconfigure/) has been supported on `start.spring.io`.
Adding, I propose to add the MyBatis testing support starter([mybatis-spring-boot-starter-test](http://mybatis.org/spring-boot-starter/mybatis-spring-boot-test-autoconfigure/)) for quick start with MyBatis slice testing.  It provide the `@MybatisTest` annotation for slice testing, version support matrix is same with the mybatis-spring-boot-starter.

WDYT?

If need to create new `entry-proposal` issue, I will create it. 