### PR TITLE
Upgrade to Spring Cloud GCP 4.5.1 and 3.5.4

### DIFF
--- a/start-site/src/main/resources/application.yml
+++ b/start-site/src/main/resources/application.yml
@@ -116,11 +116,11 @@ initializr:
           - compatibilityRange: "[2.4.0-M1,2.6.0-M1)"
             version: 2.0.11
           - compatibilityRange: "[2.6.0-M1,3.0.0-M1)"
-            version: 3.5.3
+            version: 3.5.4
           - compatibilityRange: "[3.0.0-M1,3.1.0-M1)"
-            version: 4.3.1
+            version: 4.5.1
           - compatibilityRange: "[3.1.0-M1,3.2.0-M1)"
-            version: 4.5.0
+            version: 4.5.1
       spring-cloud-services:
         groupId: io.pivotal.spring.cloud
         artifactId: spring-cloud-services-dependencies


### PR DESCRIPTION
Upgrade to Spring Cloud GCP 4.5.1 and 3.5.4.
[v4.5.1](https://github.com/GoogleCloudPlatform/spring-cloud-gcp/releases/tag/v4.5.1) supports both Spring Boot 3.0 and 3.1