### PR TITLE
Fix testcontainers site in documentation

### DIFF
--- a/start-site/src/main/java/io/spring/start/site/extension/dependency/testcontainers/TestcontainersModuleRegistry.java
+++ b/start-site/src/main/java/io/spring/start/site/extension/dependency/testcontainers/TestcontainersModuleRegistry.java
@@ -91,7 +91,7 @@ abstract class TestcontainersModuleRegistry {
 
 	private static Consumer<HelpDocument> addReferenceLink(String name, String modulePath) {
 		return (helpDocument) -> {
-			String href = String.format("https://www.testcontainers.org/modules/%s", modulePath);
+			String href = String.format("https://java.testcontainers.org/modules/%s", modulePath);
 			String description = String.format("Testcontainers %s Reference Guide", name);
 			helpDocument.gettingStarted().addReferenceDocLink(href, description);
 		};

--- a/start-site/src/test/java/io/spring/start/site/extension/dependency/springintegration/SpringIntegrationProjectGenerationConfigurationTests.java
+++ b/start-site/src/test/java/io/spring/start/site/extension/dependency/springintegration/SpringIntegrationProjectGenerationConfigurationTests.java
@@ -101,7 +101,7 @@ class SpringIntegrationProjectGenerationConfigurationTests extends AbstractExten
 	@Test
 	void linkToSupportedEntriesWhenTwoMatchesArePresentOnlyAddLinkOnce() {
 		assertHelpDocument("testcontainers", "data-mongodb", "data-mongodb-reactive")
-			.containsOnlyOnce("https://www.testcontainers.org/modules/databases/mongodb/");
+			.containsOnlyOnce("https://java.testcontainers.org/modules/databases/mongodb/");
 	}
 
 	private static Dependency integrationDependency(String id) {

--- a/start-site/src/test/java/io/spring/start/site/extension/dependency/testcontainers/TestcontainersProjectGenerationConfigurationTests.java
+++ b/start-site/src/test/java/io/spring/start/site/extension/dependency/testcontainers/TestcontainersProjectGenerationConfigurationTests.java
@@ -76,13 +76,13 @@ class TestcontainersProjectGenerationConfigurationTests extends AbstractExtensio
 	@MethodSource("supportedEntriesHelpDocument")
 	void linkToSupportedEntriesWhenTestContainerIsPresentIsAdded(String dependencyId, String docHref) {
 		assertHelpDocument("3.0.0", "testcontainers", dependencyId)
-			.contains("https://www.testcontainers.org/modules/" + docHref);
+			.contains("https://java.testcontainers.org/modules/" + docHref);
 	}
 
 	@ParameterizedTest
 	@MethodSource("supportedEntriesHelpDocument")
 	void linkToSupportedEntriesWhenTestContainerIsNotPresentIsNotAdded(String dependencyId, String docHref) {
-		assertHelpDocument("3.0.0", dependencyId).doesNotContain("https://www.testcontainers.org/modules/" + docHref);
+		assertHelpDocument("3.0.0", dependencyId).doesNotContain("https://java.testcontainers.org/modules/" + docHref);
 	}
 
 	static Stream<Arguments> supportedEntriesHelpDocument() {
@@ -109,7 +109,7 @@ class TestcontainersProjectGenerationConfigurationTests extends AbstractExtensio
 	@Test
 	void linkToSupportedEntriesWhenTwoMatchesArePresentOnlyAddLinkOnce() {
 		assertHelpDocument("3.0.0", "testcontainers", "data-mongodb", "data-mongodb-reactive")
-			.containsOnlyOnce("https://www.testcontainers.org/modules/databases/mongodb/");
+			.containsOnlyOnce("https://java.testcontainers.org/modules/databases/mongodb/");
 	}
 
 	@Test


### PR DESCRIPTION
There is no breaking change because Testcontainers already redirects
from www.testcontainers.org to java.testcontainers.org.
