### PR TITLE
Add Testcontainers GCloud module when GCP messaging and testcontainers are selected

### DIFF
--- a/start-site/src/main/java/io/spring/start/site/extension/dependency/testcontainers/TestcontainersModuleRegistry.java
+++ b/start-site/src/main/java/io/spring/start/site/extension/dependency/testcontainers/TestcontainersModuleRegistry.java
@@ -41,6 +41,8 @@ abstract class TestcontainersModuleRegistry {
 		return create(
 				onDependencies("amqp").customizeBuild(addModule("rabbitmq"))
 					.customizeHelpDocument(addReferenceLink("RabbitMQ Module", "rabbitmq/")),
+				onDependencies("cloud-gcp-pubsub").customizeBuild(addModule("gcloud"))
+					.customizeHelpDocument(addReferenceLink("GCloud Module", "gcloud/")),
 				onDependencies("cloud-starter-consul-config").customizeBuild(addModule("consul"))
 					.customizeHelpDocument(addReferenceLink("Consul Module", "consul/")),
 				onDependencies("cloud-starter-vault-config").customizeBuild(addModule("vault"))

--- a/start-site/src/main/java/io/spring/start/site/extension/dependency/testcontainers/TestcontainersModuleRegistry.java
+++ b/start-site/src/main/java/io/spring/start/site/extension/dependency/testcontainers/TestcontainersModuleRegistry.java
@@ -41,6 +41,8 @@ abstract class TestcontainersModuleRegistry {
 		return create(
 				onDependencies("amqp").customizeBuild(addModule("rabbitmq"))
 					.customizeHelpDocument(addReferenceLink("RabbitMQ Module", "rabbitmq/")),
+				onDependencies("cloud-gcp").customizeBuild(addModule("gcloud"))
+					.customizeHelpDocument(addReferenceLink("GCloud Module", "gcloud/")),
 				onDependencies("cloud-gcp-pubsub").customizeBuild(addModule("gcloud"))
 					.customizeHelpDocument(addReferenceLink("GCloud Module", "gcloud/")),
 				onDependencies("cloud-starter-consul-config").customizeBuild(addModule("consul"))

--- a/start-site/src/test/java/io/spring/start/site/extension/dependency/testcontainers/TestcontainersProjectGenerationConfigurationTests.java
+++ b/start-site/src/test/java/io/spring/start/site/extension/dependency/testcontainers/TestcontainersProjectGenerationConfigurationTests.java
@@ -58,8 +58,8 @@ class TestcontainersProjectGenerationConfigurationTests extends AbstractExtensio
 	}
 
 	static Stream<Arguments> supportedEntriesBuild() {
-		return Stream.of(Arguments.arguments("amqp", "rabbitmq"), Arguments.arguments("cloud-gcp-pubsub", "gcloud"),
-				Arguments.arguments("data-cassandra", "cassandra"),
+		return Stream.of(Arguments.arguments("amqp", "rabbitmq"), Arguments.arguments("cloud-gcp", "gcloud"),
+				Arguments.arguments("cloud-gcp-pubsub", "gcloud"), Arguments.arguments("data-cassandra", "cassandra"),
 				Arguments.arguments("data-cassandra-reactive", "cassandra"),
 				Arguments.arguments("data-couchbase", "couchbase"),
 				Arguments.arguments("data-couchbase-reactive", "couchbase"),
@@ -87,7 +87,8 @@ class TestcontainersProjectGenerationConfigurationTests extends AbstractExtensio
 	}
 
 	static Stream<Arguments> supportedEntriesHelpDocument() {
-		return Stream.of(Arguments.arguments("amqp", "rabbitmq/"), Arguments.arguments("cloud-gcp-pubsub", "gcloud/"),
+		return Stream.of(Arguments.arguments("amqp", "rabbitmq/"), Arguments.arguments("cloud-gcp", "gcloud/"),
+				Arguments.arguments("cloud-gcp-pubsub", "gcloud/"),
 				Arguments.arguments("cloud-starter-consul-config", "consul/"),
 				Arguments.arguments("cloud-starter-vault-config", "vault/"),
 				Arguments.arguments("data-cassandra", "databases/cassandra/"),

--- a/start-site/src/test/java/io/spring/start/site/extension/dependency/testcontainers/TestcontainersProjectGenerationConfigurationTests.java
+++ b/start-site/src/test/java/io/spring/start/site/extension/dependency/testcontainers/TestcontainersProjectGenerationConfigurationTests.java
@@ -58,7 +58,8 @@ class TestcontainersProjectGenerationConfigurationTests extends AbstractExtensio
 	}
 
 	static Stream<Arguments> supportedEntriesBuild() {
-		return Stream.of(Arguments.arguments("amqp", "rabbitmq"), Arguments.arguments("data-cassandra", "cassandra"),
+		return Stream.of(Arguments.arguments("amqp", "rabbitmq"), Arguments.arguments("cloud-gcp-pubsub", "gcloud"),
+				Arguments.arguments("data-cassandra", "cassandra"),
 				Arguments.arguments("data-cassandra-reactive", "cassandra"),
 				Arguments.arguments("data-couchbase", "couchbase"),
 				Arguments.arguments("data-couchbase-reactive", "couchbase"),
@@ -86,7 +87,7 @@ class TestcontainersProjectGenerationConfigurationTests extends AbstractExtensio
 	}
 
 	static Stream<Arguments> supportedEntriesHelpDocument() {
-		return Stream.of(Arguments.arguments("amqp", "rabbitmq/"),
+		return Stream.of(Arguments.arguments("amqp", "rabbitmq/"), Arguments.arguments("cloud-gcp-pubsub", "gcloud/"),
 				Arguments.arguments("cloud-starter-consul-config", "consul/"),
 				Arguments.arguments("cloud-starter-vault-config", "vault/"),
 				Arguments.arguments("data-cassandra", "databases/cassandra/"),


### PR DESCRIPTION
Testcontainers offers a GCloud module where `PubSubEmulatorContainer`
can be found and be used for testing.
