### PR TITLE
Add flyway-database-oracle dependency with spring boot 3.2.0-M1

### DIFF
--- a/start-site/src/main/java/io/spring/start/site/extension/dependency/flyway/FlywayBuildCustomizer.java
+++ b/start-site/src/main/java/io/spring/start/site/extension/dependency/flyway/FlywayBuildCustomizer.java
@@ -34,21 +34,31 @@ class FlywayBuildCustomizer implements BuildCustomizer<Build> {
 
 	private static final VersionRange SPRING_BOOT_2_7_0_OR_LATER = VersionParser.DEFAULT.parseRange("2.7.0");
 
+	private static final VersionRange SPRING_BOOT_3_2_M1_OR_LATER = VersionParser.DEFAULT.parseRange("3.2.0-M1");
+
 	private final boolean isSpringBoot27OrLater;
+
+	private final boolean isSpringBoot32OrLater;
 
 	FlywayBuildCustomizer(ProjectDescription projectDescription) {
 		this.isSpringBoot27OrLater = SPRING_BOOT_2_7_0_OR_LATER.match(projectDescription.getPlatformVersion());
+		this.isSpringBoot32OrLater = SPRING_BOOT_3_2_M1_OR_LATER.match(projectDescription.getPlatformVersion());
 	}
 
 	@Override
 	public void customize(Build build) {
+		DependencyContainer dependencies = build.dependencies();
 		if (this.isSpringBoot27OrLater) {
-			DependencyContainer dependencies = build.dependencies();
 			if ((dependencies.has("mysql") || dependencies.has("mariadb"))) {
 				dependencies.add("flyway-mysql", "org.flywaydb", "flyway-mysql", DependencyScope.COMPILE);
 			}
 			if (dependencies.has("sqlserver")) {
 				dependencies.add("flyway-sqlserver", "org.flywaydb", "flyway-sqlserver", DependencyScope.COMPILE);
+			}
+		}
+		if (this.isSpringBoot32OrLater) {
+			if (dependencies.has("oracle")) {
+				dependencies.add("flyway-oracle", "org.flywaydb", "flyway-database-oracle", DependencyScope.COMPILE);
 			}
 		}
 	}

--- a/start-site/src/test/java/io/spring/start/site/extension/dependency/flyway/FlywayBuildCustomizerTests.java
+++ b/start-site/src/test/java/io/spring/start/site/extension/dependency/flyway/FlywayBuildCustomizerTests.java
@@ -51,6 +51,13 @@ class FlywayBuildCustomizerTests extends AbstractExtensionTests {
 	}
 
 	@Test
+	void oracleOnly() {
+		ProjectRequest projectRequest = createProject("3.2.0-M1", "oracle");
+		assertThat(mavenPom(projectRequest)).hasDependency(getDependency("oracle"))
+			.doesNotHaveDependency("org.flywaydb", "flyway-database-oracle");
+	}
+
+	@Test
 	void mariadbAndFlywayPreviousTo270() {
 		ProjectRequest projectRequest = createProject("2.6.0", "mariadb", "flyway");
 		assertThat(mavenPom(projectRequest)).hasDependency(getDependency("mariadb"))
@@ -72,6 +79,13 @@ class FlywayBuildCustomizerTests extends AbstractExtensionTests {
 	}
 
 	@Test
+	void oracleAndFlywayPreviousTo32M1() {
+		ProjectRequest projectRequest = createProject("3.1.0", "oracle", "flyway");
+		assertThat(mavenPom(projectRequest)).hasDependency(getDependency("oracle"))
+			.doesNotHaveDependency("org.flywaydb", "flyway-database-oracle");
+	}
+
+	@Test
 	void mariadbAndFlyway() {
 		ProjectRequest projectRequest = createProject("2.7.0", "mariadb", "flyway");
 		assertThat(mavenPom(projectRequest)).hasDependency(getDependency("mariadb"))
@@ -90,6 +104,13 @@ class FlywayBuildCustomizerTests extends AbstractExtensionTests {
 		ProjectRequest projectRequest = createProject("2.7.0", "sqlserver", "flyway");
 		assertThat(mavenPom(projectRequest)).hasDependency(getDependency("sqlserver"))
 			.hasDependency("org.flywaydb", "flyway-sqlserver");
+	}
+
+	@Test
+	void oracleAndFlyway() {
+		ProjectRequest projectRequest = createProject("3.2.0-M1", "oracle", "flyway");
+		assertThat(mavenPom(projectRequest)).hasDependency(getDependency("oracle"))
+			.hasDependency("org.flywaydb", "flyway-database-oracle");
 	}
 
 	private ProjectRequest createProject(String springBootVersion, String... styles) {


### PR DESCRIPTION
Flyway 9.19.0 added a new depedency for oracle and Spring Boot 3.2.0-M1
started using Flyway 9.20.1. Initializr will add this new dependency
when oracle and flyway are selected along with Spring Boot 3.2.0-M1
