### PR TITLE
Upgrade to Sentry 6.28.0

### DIFF
--- a/start-site/src/main/resources/application.yml
+++ b/start-site/src/main/resources/application.yml
@@ -64,7 +64,7 @@ initializr:
         versionProperty: sentry.version
         mappings:
           - compatibilityRange: "[2.7.0,3.2.0-M1)"
-            version: 6.26.0
+            version: 6.28.0
       solace-spring-boot:
         groupId: com.solace.spring.boot
         artifactId: solace-spring-boot-bom
@@ -955,7 +955,6 @@ initializr:
           compatibilityRange: "[2.7.0,3.2.0-M1)"
           groupId: io.sentry
           artifactId: sentry-spring-boot-starter-jakarta
-          starter: false
           mappings:
             - compatibilityRange: "[2.7.0,3.0.0-M1)"
               artifactId: sentry-spring-boot-starter


### PR DESCRIPTION
Closes #1272 and removes the starter workaround that is no longer needed as https://github.com/getsentry/sentry-java/issues/2866 has been fixed in `6.28.0`.

Tested locally - build no longer fails when only adding Sentry and no other dependency.
<!--
Thanks for contributing to start.spring.io Please review the following notes before
submitting you pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Proposal for New Entries

STOP! If your contribution suggests the addition of a new entry, please do not submit it
Rather create a "New Entry Proposal" issue as we need some information from you before
proceeding.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
