### PR TITLE
Add io.asyncer:r2dbc-mysql when spring boot 3.1 is selected

### DIFF
--- a/start-site/src/main/java/io/spring/start/site/extension/dependency/springdata/R2dbcBuildCustomizer.java
+++ b/start-site/src/main/java/io/spring/start/site/extension/dependency/springdata/R2dbcBuildCustomizer.java
@@ -38,6 +38,7 @@ import io.spring.initializr.generator.version.VersionReference;
  * @author Stephane Nicoll
  * @author Andy Wilkinson
  * @author Brian Clozel
+ * @author Eddú Meléndez
  */
 public class R2dbcBuildCustomizer implements BuildCustomizer<Build> {
 
@@ -47,16 +48,21 @@ public class R2dbcBuildCustomizer implements BuildCustomizer<Build> {
 
 	private static final VersionRange SPRING_BOOT_3_0_0_OR_LATER = VersionParser.DEFAULT.parseRange("3.0.0-M1");
 
+	private static final VersionRange SPRING_BOOT_3_1_0_OR_LATER = VersionParser.DEFAULT.parseRange("3.1.0");
+
 	private final boolean borcaOrLater;
 
 	private final boolean mariaDbIsUnmanaged;
 
 	private final boolean sqlServerIsUnmanaged;
 
+	private final boolean mysqlR2dbcNewDependency;
+
 	public R2dbcBuildCustomizer(Version platformVersion) {
 		this.borcaOrLater = SPRING_BOOT_2_7_0_OR_LATER.match(platformVersion);
 		this.mariaDbIsUnmanaged = SPRING_BOOT_3_0_0_OR_LATER.match(platformVersion);
 		this.sqlServerIsUnmanaged = SPRING_BOOT_3_0_0_OR_LATER.match(platformVersion);
+		this.mysqlR2dbcNewDependency = SPRING_BOOT_3_1_0_OR_LATER.match(platformVersion);
 	}
 
 	@Override
@@ -70,6 +76,9 @@ public class R2dbcBuildCustomizer implements BuildCustomizer<Build> {
 		}
 		if (build.dependencies().has("mysql") && !this.borcaOrLater) {
 			addManagedDriver(build.dependencies(), "dev.miku", "r2dbc-mysql");
+		}
+		if (build.dependencies().has("mysql") && this.mysqlR2dbcNewDependency) {
+			addManagedDriver(build.dependencies(), "io.asyncer", "r2dbc-mysql");
 		}
 		if (build.dependencies().has("postgresql")) {
 			String groupId = this.borcaOrLater ? "org.postgresql" : "io.r2dbc";

--- a/start-site/src/test/java/io/spring/start/site/extension/dependency/springdata/R2dbcBuildCustomizerTests.java
+++ b/start-site/src/test/java/io/spring/start/site/extension/dependency/springdata/R2dbcBuildCustomizerTests.java
@@ -33,6 +33,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * Tests for {@link R2dbcBuildCustomizer}.
  *
  * @author Stephane Nicoll
+ * @author Eddú Meléndez
  */
 class R2dbcBuildCustomizerTests extends AbstractExtensionTests {
 
@@ -72,6 +73,7 @@ class R2dbcBuildCustomizerTests extends AbstractExtensionTests {
 		build.dependencies().add("mysql");
 		customize(build, Version.parse("2.6.8"));
 		assertThat(build.dependencies().ids()).containsOnly("data-r2dbc", "mysql", "r2dbc-mysql");
+		assertThat(build.dependencies().get("r2dbc-mysql").getGroupId()).isEqualTo("dev.miku");
 	}
 
 	@Test
@@ -81,6 +83,16 @@ class R2dbcBuildCustomizerTests extends AbstractExtensionTests {
 		build.dependencies().add("mysql");
 		customize(build, Version.parse("2.7.0"));
 		assertThat(build.dependencies().ids()).containsOnly("data-r2dbc", "mysql");
+	}
+
+	@Test
+	void r2dbcWithMysqlAndSpringBoot31() {
+		Build build = createBuild();
+		build.dependencies().add("data-r2dbc");
+		build.dependencies().add("mysql");
+		customize(build, Version.parse("3.1.0"));
+		assertThat(build.dependencies().ids()).containsOnly("data-r2dbc", "mysql", "r2dbc-mysql");
+		assertThat(build.dependencies().get("r2dbc-mysql").getGroupId()).isEqualTo("io.asyncer");
 	}
 
 	@Test


### PR DESCRIPTION
`io.asyncer:r2dbc-mysql` was added in the dependency management
in spring boot 3.1. Currently, when r2dbc and mysql are selected
the generated project doesn't include the new dependepency. This
commit fix the behavior.
