### PR TITLE
Add Pulsar Binder to Spring Cloud Stream

### DIFF
--- a/start-site/src/main/java/io/spring/start/site/extension/dependency/springcloud/SpringCloudStreamBuildCustomizer.java
+++ b/start-site/src/main/java/io/spring/start/site/extension/dependency/springcloud/SpringCloudStreamBuildCustomizer.java
@@ -57,6 +57,11 @@ class SpringCloudStreamBuildCustomizer implements BuildCustomizer<Build> {
 					.add("cloud-stream-binder-kafka", "org.springframework.cloud", "spring-cloud-stream-binder-kafka",
 							DependencyScope.COMPILE);
 			}
+			if (isSpringBoot3xWithPulsarSupport() && hasDependency("pulsar", build)) {
+				build.dependencies()
+					.add("cloud-stream-binder-pulsar", "org.springframework.cloud", "spring-cloud-stream-binder-pulsar",
+							DependencyScope.COMPILE);
+			}
 		}
 		// Spring Cloud Stream specific
 		if (hasDependency("cloud-stream", build)) {
@@ -90,6 +95,11 @@ class SpringCloudStreamBuildCustomizer implements BuildCustomizer<Build> {
 	protected boolean isSpringBoot3x() {
 		Version platformVersion = this.description.getPlatformVersion();
 		return platformVersion.compareTo(Version.parse("3.0.0-M1")) > 0;
+	}
+
+	protected boolean isSpringBoot3xWithPulsarSupport() {
+		Version platformVersion = this.description.getPlatformVersion();
+		return platformVersion.compareTo(Version.parse("3.2.0-M3")) >= 0;
 	}
 
 }

--- a/start-site/src/test/java/io/spring/start/site/extension/dependency/springcloud/SpringCloudStreamBuildCustomizerTests.java
+++ b/start-site/src/test/java/io/spring/start/site/extension/dependency/springcloud/SpringCloudStreamBuildCustomizerTests.java
@@ -34,6 +34,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  *
  * @author Stephane Nicoll
  * @author Brian Clozel
+ * @author Chris Bono
  */
 class SpringCloudStreamBuildCustomizerTests extends AbstractExtensionTests {
 
@@ -42,6 +43,9 @@ class SpringCloudStreamBuildCustomizerTests extends AbstractExtensionTests {
 
 	private static final Dependency KAFKA_STREAMS_BINDER = Dependency.withId("cloud-stream-binder-kafka-streams",
 			"org.springframework.cloud", "spring-cloud-stream-binder-kafka-streams");
+
+	private static final Dependency PULSAR_BINDER = Dependency.withId("cloud-stream-binder-pulsar",
+			"org.springframework.cloud", "spring-cloud-stream-binder-pulsar");
 
 	private static final Dependency RABBIT_BINDER = Dependency.withId("cloud-stream-binder-rabbit",
 			"org.springframework.cloud", "spring-cloud-stream-binder-rabbit");
@@ -86,6 +90,19 @@ class SpringCloudStreamBuildCustomizerTests extends AbstractExtensionTests {
 	}
 
 	@ParameterizedTest
+	@MethodSource("springCloudStreamWithPulsarArguments")
+	void springCloudStreamWithPulsar(Version springBootVersion, Dependency testDependency) {
+		ProjectRequest request = createProjectRequest("cloud-stream", "pulsar");
+		request.setBootVersion(springBootVersion.toString());
+		assertThat(mavenPom(request)).hasDependency(getDependency("cloud-stream"))
+			.hasDependency(getDependency("pulsar"))
+			.hasDependency(PULSAR_BINDER)
+			.hasDependency(Dependency.createSpringBootStarter("test", Dependency.SCOPE_TEST))
+			.hasDependency(testDependency)
+			.hasDependenciesSize(5);
+	}
+
+	@ParameterizedTest
 	@MethodSource("springCloudStreamArguments")
 	void springCloudStreamWithAllBinders(Version springBootVersion, Dependency testDependency) {
 		ProjectRequest request = createProjectRequest("cloud-stream", "amqp", "kafka", "kafka-streams");
@@ -103,8 +120,27 @@ class SpringCloudStreamBuildCustomizerTests extends AbstractExtensionTests {
 	}
 
 	@ParameterizedTest
+	@MethodSource("springCloudStreamWithPulsarArguments")
+	void springCloudStreamWithAllBindersInBoot32x(Version springBootVersion, Dependency testDependency) {
+		ProjectRequest request = createProjectRequest("cloud-stream", "amqp", "kafka", "kafka-streams", "pulsar");
+		request.setBootVersion(springBootVersion.toString());
+		assertThat(mavenPom(request)).hasDependency(getDependency("cloud-stream"))
+			.hasDependency(getDependency("amqp"))
+			.hasDependency(getDependency("kafka"))
+			.hasDependency(getDependency("kafka-streams"))
+			.hasDependency(getDependency("pulsar"))
+			.hasDependency(RABBIT_BINDER)
+			.hasDependency(KAFKA_BINDER)
+			.hasDependency(KAFKA_STREAMS_BINDER)
+			.hasDependency(PULSAR_BINDER)
+			.hasDependency(Dependency.createSpringBootStarter("test", Dependency.SCOPE_TEST))
+			.hasDependency(testDependency)
+			.hasDependenciesSize(13);
+	}
+
+	@ParameterizedTest
 	@MethodSource("springCloudStreamArguments")
-	void springCloudBusWithRabbit(Version springBootVersion, Dependency testDependency) {
+	void springCloudBusWithRabbit(Version springBootVersion, Dependency ignoredTestDependency) {
 		ProjectRequest request = createProjectRequest("cloud-bus", "amqp");
 		request.setBootVersion(springBootVersion.toString());
 		assertThat(mavenPom(request)).hasDependency(getDependency("cloud-bus"))
@@ -116,29 +152,43 @@ class SpringCloudStreamBuildCustomizerTests extends AbstractExtensionTests {
 
 	@ParameterizedTest
 	@MethodSource("springCloudStreamArguments")
-	void springCloudBusWithKafka(Version springBootVersion, Dependency testDependency) {
-		ProjectRequest request = createProjectRequest("cloud-bus", "amqp");
+	void springCloudBusWithKafka(Version springBootVersion, Dependency ignoredTestDependency) {
+		ProjectRequest request = createProjectRequest("cloud-bus", "kafka");
 		request.setBootVersion(springBootVersion.toString());
 		assertThat(mavenPom(request)).hasDependency(getDependency("cloud-bus"))
-			.hasDependency(getDependency("amqp"))
-			.hasDependency(RABBIT_BINDER)
+			.hasDependency(getDependency("kafka"))
+			.hasDependency(KAFKA_BINDER)
 			.hasDependency(Dependency.createSpringBootStarter("test", Dependency.SCOPE_TEST))
 			.hasDependenciesSize(5);
 	}
 
 	@ParameterizedTest
-	@MethodSource("springCloudStreamArguments")
-	void springCloudBusWithAllBinders(Version springBootVersion, Dependency testDependency) {
-		ProjectRequest request = createProjectRequest("cloud-bus", "amqp", "kafka", "kafka-streams");
+	@MethodSource("springCloudStreamWithPulsarArguments")
+	void springCloudBusWithPulsar(Version springBootVersion, Dependency ignoredTestDependency) {
+		ProjectRequest request = createProjectRequest("cloud-bus", "pulsar");
+		request.setBootVersion(springBootVersion.toString());
+		assertThat(mavenPom(request)).hasDependency(getDependency("cloud-bus"))
+			.hasDependency(getDependency("pulsar"))
+			.hasDependency(PULSAR_BINDER)
+			.hasDependency(Dependency.createSpringBootStarter("test", Dependency.SCOPE_TEST))
+			.hasDependenciesSize(4);
+	}
+
+	@ParameterizedTest
+	@MethodSource("springCloudStreamWithPulsarArguments")
+	void springCloudBusWithAllBindersInBoot32x(Version springBootVersion, Dependency ignoredTestDependency) {
+		ProjectRequest request = createProjectRequest("cloud-bus", "amqp", "kafka", "kafka-streams", "pulsar");
 		request.setBootVersion(springBootVersion.toString());
 		assertThat(mavenPom(request)).hasDependency(getDependency("cloud-bus"))
 			.hasDependency(getDependency("amqp"))
 			.hasDependency(getDependency("kafka"))
 			.hasDependency(getDependency("kafka-streams"))
+			.hasDependency(getDependency("pulsar"))
 			.hasDependency(RABBIT_BINDER)
 			.hasDependency(KAFKA_BINDER)
+			.hasDependency(PULSAR_BINDER)
 			.hasDependency(Dependency.createSpringBootStarter("test", Dependency.SCOPE_TEST))
-			.hasDependenciesSize(9);
+			.hasDependenciesSize(11);
 	}
 
 	@Test
@@ -157,6 +207,13 @@ class SpringCloudStreamBuildCustomizerTests extends AbstractExtensionTests {
 				"spring-cloud-stream-test-binder", null, Dependency.SCOPE_TEST);
 		return Stream.of(Arguments.of(Version.parse("2.7.0"), scsTest),
 				Arguments.of(Version.parse("3.0.0"), testBinder));
+	}
+
+	private static Stream<Arguments> springCloudStreamWithPulsarArguments() {
+		Dependency testBinder = Dependency.withId("cloud-stream-test", "org.springframework.cloud",
+				"spring-cloud-stream-test-binder", null, Dependency.SCOPE_TEST);
+		return Stream.of(Arguments.of(Version.parse("3.2.0-M3"), testBinder),
+				Arguments.of(Version.parse("3.2.0-RC1"), testBinder));
 	}
 
 }


### PR DESCRIPTION
This commit ensures the Spring Cloud Stream Pulsar binder dependency is automatically added when the user chooses Spring Boot >= 3.2.0-M3 and adds the Pulsar and Cloud Stream dependencies.

This was not an issue in the older Spring Pulsar `0.2.x` offering because the binder was contained in the Spring Pulsar repo. Now the binder has been moved into SCSt proper, the binder dependency must be added as well. I missed this detail in my original update to Pulsar/Boot32.
