### PR TITLE
Add Netflix DGS Codegen plugin support

### DIFF
--- a/start-site/src/main/java/io/spring/start/site/extension/dependency/dgs/DgsCodegenBuildCustomizer.java
+++ b/start-site/src/main/java/io/spring/start/site/extension/dependency/dgs/DgsCodegenBuildCustomizer.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2012-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.spring.start.site.extension.dependency.dgs;
+
+import io.spring.initializr.generator.buildsystem.Build;
+import io.spring.initializr.generator.spring.build.BuildCustomizer;
+
+import org.springframework.core.Ordered;
+
+/**
+ * {@link BuildCustomizer} that removes the "dgs-codegen" dependency as this is a build
+ * plugin only dependency.
+ *
+ * @author Brian Clozel
+ */
+class DgsCodegenBuildCustomizer implements BuildCustomizer<Build> {
+
+	@Override
+	public void customize(Build build) {
+		build.dependencies().remove("dgs-codegen");
+	}
+
+	@Override
+	public int getOrder() {
+		return Ordered.LOWEST_PRECEDENCE - 10;
+	}
+
+}

--- a/start-site/src/main/java/io/spring/start/site/extension/dependency/dgs/DgsCodegenGroovyDslGradleBuildCustomizer.java
+++ b/start-site/src/main/java/io/spring/start/site/extension/dependency/dgs/DgsCodegenGroovyDslGradleBuildCustomizer.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2012-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.spring.start.site.extension.dependency.dgs;
+
+import io.spring.initializr.generator.buildsystem.gradle.GradleBuild;
+import io.spring.initializr.generator.spring.build.BuildCustomizer;
+
+/**
+ * {@link BuildCustomizer} for Gradle Groovy DSL projects using DGS Codegen.
+ *
+ * @author Brian Clozel
+ */
+class DgsCodegenGroovyDslGradleBuildCustomizer implements BuildCustomizer<GradleBuild> {
+
+	private final String pluginVersion;
+
+	private final String packageName;
+
+	DgsCodegenGroovyDslGradleBuildCustomizer(String pluginVersion, String packageName) {
+		this.pluginVersion = pluginVersion;
+		this.packageName = packageName;
+	}
+
+	@Override
+	public void customize(GradleBuild build) {
+		build.plugins().add("com.netflix.dgs.codegen", (plugin) -> plugin.setVersion(this.pluginVersion));
+		build.snippets().add((writer) -> {
+			writer.println("generateJava {");
+			writer.indented(() -> {
+				writer.println("schemaPaths = [\"${projectDir}/src/main/resources/graphql-client\"]");
+				writer.println("packageName = '" + this.packageName + ".codegen'");
+				writer.println("generateClient = true");
+			});
+			writer.println("}");
+		});
+	}
+
+}

--- a/start-site/src/main/java/io/spring/start/site/extension/dependency/dgs/DgsCodegenHelpDocumentCustomizer.java
+++ b/start-site/src/main/java/io/spring/start/site/extension/dependency/dgs/DgsCodegenHelpDocumentCustomizer.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2012-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.spring.start.site.extension.dependency.dgs;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import io.spring.initializr.generator.buildsystem.BuildSystem;
+import io.spring.initializr.generator.buildsystem.gradle.GradleBuildSystem;
+import io.spring.initializr.generator.buildsystem.maven.MavenBuildSystem;
+import io.spring.initializr.generator.project.ProjectDescription;
+import io.spring.initializr.generator.spring.documentation.HelpDocument;
+import io.spring.initializr.generator.spring.documentation.HelpDocumentCustomizer;
+
+/**
+ * Provide additional information when DGS Codegen Support is selected.
+ *
+ * @author Brian Clozel
+ */
+class DgsCodegenHelpDocumentCustomizer implements HelpDocumentCustomizer {
+
+	private final BuildSystem buildSystem;
+
+	DgsCodegenHelpDocumentCustomizer(ProjectDescription description) {
+		this.buildSystem = description.getBuildSystem();
+	}
+
+	@Override
+	public void customize(HelpDocument document) {
+		Map<String, Object> model = new HashMap<>();
+
+		if (MavenBuildSystem.ID.equals(this.buildSystem.id())) {
+			model.put("dsgCodegenOptionsLink", "https://github.com/deweyjose/graphqlcodegen");
+		}
+		else if (GradleBuildSystem.ID.equals(this.buildSystem.id())) {
+			model.put("dsgCodegenOptionsLink",
+					"https://netflix.github.io/dgs/generating-code-from-schema/#configuring-code-generation");
+		}
+		document.addSection("dgscodegen", model);
+	}
+
+}

--- a/start-site/src/main/java/io/spring/start/site/extension/dependency/dgs/DgsCodegenKotlinDslGradleBuildCustomizer.java
+++ b/start-site/src/main/java/io/spring/start/site/extension/dependency/dgs/DgsCodegenKotlinDslGradleBuildCustomizer.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2012-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.spring.start.site.extension.dependency.dgs;
+
+import io.spring.initializr.generator.buildsystem.gradle.GradleBuild;
+import io.spring.initializr.generator.spring.build.BuildCustomizer;
+
+/**
+ * {@link BuildCustomizer} for Gradle Kotlin DSL projects using DGS Codegen.
+ *
+ * @author Brian Clozel
+ */
+class DgsCodegenKotlinDslGradleBuildCustomizer implements BuildCustomizer<GradleBuild> {
+
+	private final String pluginVersion;
+
+	private final String packageName;
+
+	DgsCodegenKotlinDslGradleBuildCustomizer(String pluginVersion, String packageName) {
+		this.pluginVersion = pluginVersion;
+		this.packageName = packageName;
+	}
+
+	@Override
+	public void customize(GradleBuild build) {
+		build.plugins().add("com.netflix.dgs.codegen", (plugin) -> plugin.setVersion(this.pluginVersion));
+		build.snippets().add((writer) -> {
+			writer.println("tasks.generateJava {");
+			writer.indented(() -> {
+				writer.println("schemaPaths.add(\"${projectDir}/src/main/resources/graphql-client\")");
+				writer.println("packageName = \"" + this.packageName + ".codegen\"");
+				writer.println("generateClient = true");
+			});
+			writer.println("}");
+		});
+	}
+
+}

--- a/start-site/src/main/java/io/spring/start/site/extension/dependency/dgs/DgsCodegenMavenBuildCustomizer.java
+++ b/start-site/src/main/java/io/spring/start/site/extension/dependency/dgs/DgsCodegenMavenBuildCustomizer.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2012-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.spring.start.site.extension.dependency.dgs;
+
+import io.spring.initializr.generator.buildsystem.maven.MavenBuild;
+import io.spring.initializr.generator.spring.build.BuildCustomizer;
+
+/**
+ * {@link BuildCustomizer} for Maven projects using DGS Codegen (community maintained).
+ *
+ * @author Brian Clozel
+ * @see <a href="https://github.com/deweyjose/graphqlcodegen">Maven GraphQL Codegen
+ * plugin</a>
+ */
+public class DgsCodegenMavenBuildCustomizer implements BuildCustomizer<MavenBuild> {
+
+	private final String pluginVersion;
+
+	private final String packageName;
+
+	public DgsCodegenMavenBuildCustomizer(String pluginVersion, String packageName) {
+		this.pluginVersion = pluginVersion;
+		this.packageName = packageName;
+	}
+
+	@Override
+	public void customize(MavenBuild build) {
+		build.plugins()
+			.add("io.github.deweyjose", "graphqlcodegen-maven-plugin",
+					(plugin) -> plugin.version(this.pluginVersion)
+						.execution("dgs-codegen",
+								(execution) -> execution.goal("generate")
+									.configuration((configuration) -> configuration
+										.add("schemaPaths",
+												(schemaPaths) -> schemaPaths.add("param",
+														"src/main/resources/graphql-client"))
+										.add("packageName", this.packageName + ".codegen")
+										.add("addGeneratedAnnotation", "true"))));
+		build.plugins()
+			.add("org.codehaus.mojo", "build-helper-maven-plugin",
+					(plugin) -> plugin.execution("add-dgs-source", (execution) -> execution.goal("add-source")
+						.phase("generate-sources")
+						.configuration((configuration) -> configuration.add("sources",
+								(sources) -> sources.add("source", "${project.build.directory}/generated-sources")))));
+	}
+
+}

--- a/start-site/src/main/java/io/spring/start/site/extension/dependency/dgs/DgsCodegenProjectContributor.java
+++ b/start-site/src/main/java/io/spring/start/site/extension/dependency/dgs/DgsCodegenProjectContributor.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2012-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.spring.start.site.extension.dependency.dgs;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import io.spring.initializr.generator.project.contributor.ProjectContributor;
+
+/**
+ * A {@link ProjectContributor} that creates the "graphql-client" resources directory when
+ * the DGS Codegen build plugin is requested.
+ *
+ * @author Brian Clozel
+ */
+class DgsCodegenProjectContributor implements ProjectContributor {
+
+	@Override
+	public void contribute(Path projectRoot) throws IOException {
+		Path graphQlDirectory = projectRoot.resolve("src/main/resources/graphql-client");
+		Files.createDirectories(graphQlDirectory);
+	}
+
+}

--- a/start-site/src/main/java/io/spring/start/site/extension/dependency/dgs/DgsCodegenProjectGenerationConfiguration.java
+++ b/start-site/src/main/java/io/spring/start/site/extension/dependency/dgs/DgsCodegenProjectGenerationConfiguration.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2012-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.spring.start.site.extension.dependency.dgs;
+
+import io.spring.initializr.generator.buildsystem.gradle.GradleBuildSystem;
+import io.spring.initializr.generator.buildsystem.maven.MavenBuildSystem;
+import io.spring.initializr.generator.condition.ConditionalOnBuildSystem;
+import io.spring.initializr.generator.condition.ConditionalOnPlatformVersion;
+import io.spring.initializr.generator.condition.ConditionalOnRequestedDependency;
+import io.spring.initializr.generator.project.ProjectDescription;
+import io.spring.initializr.generator.project.ProjectGenerationConfiguration;
+import io.spring.initializr.metadata.InitializrMetadata;
+
+import org.springframework.context.annotation.Bean;
+
+/**
+ * {@link ProjectGenerationConfiguration} for generation of projects that use the Netflix
+ * DGS codegen.
+ *
+ * @author Brian Clozel
+ * @see <a href="https://netflix.github.io/dgs/generating-code-from-schema/">Netflix DGS
+ * codegen</a>
+ */
+@ProjectGenerationConfiguration
+@ConditionalOnRequestedDependency("dgs-codegen")
+@ConditionalOnPlatformVersion("3.0.0-M1")
+class DgsCodegenProjectGenerationConfiguration {
+
+	private final String dgsCodegenPluginVersion;
+
+	DgsCodegenProjectGenerationConfiguration(InitializrMetadata metadata, ProjectDescription description) {
+		this.dgsCodegenPluginVersion = DgsCodegenVersionResolver.resolve(metadata, description.getPlatformVersion(),
+				description.getBuildSystem());
+	}
+
+	@Bean
+	DgsCodegenBuildCustomizer dgsCodegenBuildCustomizer() {
+		return new DgsCodegenBuildCustomizer();
+	}
+
+	@Bean
+	DgsCodegenProjectContributor dgsCodegenProjectContributor() {
+		return new DgsCodegenProjectContributor();
+	}
+
+	@Bean
+	DgsCodegenHelpDocumentCustomizer dgsCodegenHelpDocumentCustomizer(ProjectDescription description) {
+		return new DgsCodegenHelpDocumentCustomizer(description);
+	}
+
+	@Bean
+	@ConditionalOnBuildSystem(id = GradleBuildSystem.ID, dialect = GradleBuildSystem.DIALECT_GROOVY)
+	DgsCodegenGroovyDslGradleBuildCustomizer dgsCodegenGroovyDslGradleBuildCustomizer(ProjectDescription description) {
+		return new DgsCodegenGroovyDslGradleBuildCustomizer(this.dgsCodegenPluginVersion, description.getPackageName());
+	}
+
+	@Bean
+	@ConditionalOnBuildSystem(id = GradleBuildSystem.ID, dialect = GradleBuildSystem.DIALECT_KOTLIN)
+	DgsCodegenKotlinDslGradleBuildCustomizer dgsCodegenKotlinDslGradleBuildCustomizer(ProjectDescription description) {
+		return new DgsCodegenKotlinDslGradleBuildCustomizer(this.dgsCodegenPluginVersion, description.getPackageName());
+	}
+
+	@Bean
+	@ConditionalOnBuildSystem(MavenBuildSystem.ID)
+	DgsCodegenMavenBuildCustomizer dgsCodegenMavenBuildCustomizer(ProjectDescription description) {
+		return new DgsCodegenMavenBuildCustomizer(this.dgsCodegenPluginVersion, description.getPackageName());
+	}
+
+}

--- a/start-site/src/main/java/io/spring/start/site/extension/dependency/dgs/DgsCodegenVersionResolver.java
+++ b/start-site/src/main/java/io/spring/start/site/extension/dependency/dgs/DgsCodegenVersionResolver.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2012-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.spring.start.site.extension.dependency.dgs;
+
+import io.spring.initializr.generator.buildsystem.BuildSystem;
+import io.spring.initializr.generator.buildsystem.gradle.GradleBuildSystem;
+import io.spring.initializr.generator.buildsystem.maven.MavenBuildSystem;
+import io.spring.initializr.generator.version.Version;
+import io.spring.initializr.metadata.InitializrMetadata;
+
+/**
+ * Resolve DGS Codegen plugin version to use based on the platform version and build
+ * system.
+ *
+ * @author Brian Clozel
+ */
+abstract class DgsCodegenVersionResolver {
+
+	static String resolve(InitializrMetadata metadata, Version platformVersion, BuildSystem build) {
+		if (GradleBuildSystem.ID.equals(build.id())) {
+			return metadata.getDependencies().get("dgs-codegen").resolve(platformVersion).getVersion();
+		}
+		else if (MavenBuildSystem.ID.equals(build.id())) {
+			// https://github.com/deweyjose/graphqlcodegen/releases
+			return "1.50";
+		}
+		throw new IllegalArgumentException("Could not resolve DGS Codegen version for build system " + build.id());
+	}
+
+}

--- a/start-site/src/main/java/io/spring/start/site/extension/dependency/dgs/package-info.java
+++ b/start-site/src/main/java/io/spring/start/site/extension/dependency/dgs/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2012-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Extensions for generation of projects that use the Netflix Domain Graph Service.
+ */
+package io.spring.start.site.extension.dependency.dgs;

--- a/start-site/src/main/resources/META-INF/spring.factories
+++ b/start-site/src/main/resources/META-INF/spring.factories
@@ -5,6 +5,7 @@ io.spring.start.site.extension.dependency.DependencyProjectGenerationConfigurati
 io.spring.start.site.extension.dependency.activemq.ActiveMQProjectGenerationConfiguration,\
 io.spring.start.site.extension.dependency.cassandra.CassandraProjectGenerationConfiguration,\
 io.spring.start.site.extension.dependency.derby.DerbyProjectGenerationConfiguration,\
+io.spring.start.site.extension.dependency.dgs.DgsCodegenProjectGenerationConfiguration,\
 io.spring.start.site.extension.dependency.dockercompose.DockerComposeProjectGenerationConfiguration,\
 io.spring.start.site.extension.dependency.elasticsearch.ElasticsearchProjectGenerationConfiguration,\
 io.spring.start.site.extension.dependency.flyway.FlywayProjectGenerationConfiguration,\

--- a/start-site/src/main/resources/application.yml
+++ b/start-site/src/main/resources/application.yml
@@ -203,6 +203,16 @@ initializr:
           artifactId: spring-boot
           description: Support for compiling Spring applications to native executables using the GraalVM native-image compiler.
           starter: false
+        - name: GraphQL DGS Code Generation
+          id: dgs-codegen
+          compatibilityRange: "3.0.0-M1"
+          groupId: com.netflix.graphql.dgs.codegen
+          artifactId: graphql-dgs-codegen-gradle
+          mappings:
+            - compatibilityRange: "3.0.0-M1"
+              version: 6.0.3
+          description: Generate data types and type-safe APIs for querying GraphQL APIs by parsing schema files.
+          starter: false
         - name: Spring Boot DevTools
           id: devtools
           groupId: org.springframework.boot

--- a/start-site/src/main/resources/templates/dgscodegen.mustache
+++ b/start-site/src/main/resources/templates/dgscodegen.mustache
@@ -1,0 +1,9 @@
+## GraphQL code generation with DGS
+
+This project has been configured to use the Netflix DGS Codegen plugin.
+This plugin can be used to generate client files for accessing remote GraphQL services.
+The default setup assumes that the GraphQL schema file for the remote service is added to the `src/main/resources/graphql-client/` location.
+
+You can learn more about the [plugin configuration options]({{dsgCodegenOptionsLink}}) and
+[how to use the generated types](https://netflix.github.io/dgs/generating-code-from-schema/) to adapt the default setup.
+

--- a/start-site/src/test/java/io/spring/start/site/extension/dependency/dgs/DgsCodegenBuildCustomizerTests.java
+++ b/start-site/src/test/java/io/spring/start/site/extension/dependency/dgs/DgsCodegenBuildCustomizerTests.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2012-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.spring.start.site.extension.dependency.dgs;
+
+import io.spring.initializr.generator.buildsystem.Dependency;
+import io.spring.initializr.generator.buildsystem.gradle.GradleBuild;
+import io.spring.initializr.generator.buildsystem.maven.MavenBuild;
+import io.spring.initializr.generator.version.VersionReference;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link DgsCodegenBuildCustomizer}.
+ *
+ * @author Brian Clozel
+ */
+public class DgsCodegenBuildCustomizerTests {
+
+	@Test
+	void gradleBuildShouldRemoveCodegenDependency() {
+		DgsCodegenBuildCustomizer customizer = new DgsCodegenBuildCustomizer();
+		GradleBuild build = new GradleBuild();
+		build.dependencies()
+			.add("dgs-codegen",
+					Dependency.withCoordinates("com.example", "dgs-codegen")
+						.version(VersionReference.ofProperty("dgs-codegen.version"))
+						.build());
+		customizer.customize(build);
+		assertThat(build.dependencies().has("dgs-codegen")).isFalse();
+	}
+
+	@Test
+	void mavenBuildShouldRemoveCodegenDependency() {
+		DgsCodegenBuildCustomizer customizer = new DgsCodegenBuildCustomizer();
+		MavenBuild build = new MavenBuild();
+		build.dependencies()
+			.add("dgs-codegen",
+					Dependency.withCoordinates("com.example", "dgs-codegen")
+						.version(VersionReference.ofProperty("dgs-codegen.version"))
+						.build());
+		customizer.customize(build);
+		assertThat(build.dependencies().has("dgs-codegen")).isFalse();
+	}
+
+}

--- a/start-site/src/test/java/io/spring/start/site/extension/dependency/dgs/DgsCodegenHelpDocumentCustomizerTests.java
+++ b/start-site/src/test/java/io/spring/start/site/extension/dependency/dgs/DgsCodegenHelpDocumentCustomizerTests.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2012-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.spring.start.site.extension.dependency.dgs;
+
+import io.spring.initializr.generator.io.template.MustacheTemplateRenderer;
+import io.spring.initializr.generator.test.io.TextAssert;
+import io.spring.initializr.generator.test.project.ProjectStructure;
+import io.spring.initializr.web.project.ProjectRequest;
+import io.spring.start.site.extension.AbstractExtensionTests;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.beans.factory.annotation.Autowired;
+
+/**
+ * Tests for {@link DgsCodegenHelpDocumentCustomizer}.
+ *
+ * @author Brian Clozel
+ */
+class DgsCodegenHelpDocumentCustomizerTests extends AbstractExtensionTests {
+
+	@Autowired
+	private MustacheTemplateRenderer templateRenderer;
+
+	@Test
+	void mavenBuildAddsLinkToMavenCodegenPlugin() {
+
+		assertHelpDocument("maven-project", "dgs-codegen").contains("## GraphQL code generation with DGS")
+			.contains("[plugin configuration options](https://github.com/deweyjose/graphqlcodegen)");
+	}
+
+	@Test
+	void gradleBuildAddsLinkToGradleCodegenPlugin() {
+		assertHelpDocument("gradle-project", "dgs-codegen").contains("## GraphQL code generation with DGS")
+			.contains(
+					"[plugin configuration options](https://netflix.github.io/dgs/generating-code-from-schema/#configuring-code-generation)");
+	}
+
+	private TextAssert assertHelpDocument(String type, String... dependencies) {
+		ProjectRequest request = createProjectRequest(dependencies);
+		request.setType(type);
+		ProjectStructure project = generateProject(request);
+		return new TextAssert(project.getProjectDirectory().resolve("HELP.md"));
+	}
+
+}

--- a/start-site/src/test/java/io/spring/start/site/extension/dependency/dgs/DgsCodegenProjectContributorTests.java
+++ b/start-site/src/test/java/io/spring/start/site/extension/dependency/dgs/DgsCodegenProjectContributorTests.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2012-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.spring.start.site.extension.dependency.dgs;
+
+import io.spring.initializr.generator.test.project.ProjectStructure;
+import io.spring.initializr.web.project.ProjectRequest;
+import io.spring.start.site.extension.AbstractExtensionTests;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link DgsCodegenProjectContributor}.
+ *
+ * @author Brian Clozel
+ */
+class DgsCodegenProjectContributorTests extends AbstractExtensionTests {
+
+	@Test
+	void graphqlClientResourceDirectoryIsCreatedWithDgsCodegen() {
+		ProjectRequest request = createProjectRequest("dgs-codegen");
+		ProjectStructure structure = generateProject(request);
+		assertThat(structure.getProjectDirectory().resolve("src/main/resources/graphql-client")).exists().isDirectory();
+	}
+
+	@Test
+	void graphqlClientResourceDirectoryIsNotCreatedIfDgsCodegenIsNotRequested() {
+		ProjectRequest request = createProjectRequest("web");
+		ProjectStructure structure = generateProject(request);
+		assertThat(structure.getProjectDirectory().resolve("src/main/resources/graphql-client")).doesNotExist();
+	}
+
+}

--- a/start-site/src/test/java/io/spring/start/site/extension/dependency/dgs/DgsCodegenProjectGenerationConfigurationTests.java
+++ b/start-site/src/test/java/io/spring/start/site/extension/dependency/dgs/DgsCodegenProjectGenerationConfigurationTests.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2012-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.spring.start.site.extension.dependency.dgs;
+
+import io.spring.initializr.web.project.ProjectRequest;
+import io.spring.start.site.extension.AbstractExtensionTests;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link DgsCodegenProjectGenerationConfiguration}.
+ *
+ * @author Brian Clozel
+ */
+class DgsCodegenProjectGenerationConfigurationTests extends AbstractExtensionTests {
+
+	@Test
+	void gradleBuildWithoutDgsCodegenDoesNotConfigureCodegenPlugin() {
+		ProjectRequest request = createProjectRequest("web");
+		assertThat(gradleBuild(request)).doesNotContain("com.netflix.dgs.codegen");
+	}
+
+	@Test
+	void mavenBuildWithoutDgsCodegenDoesNotConfigureCodegenPlugin() {
+		ProjectRequest request = createProjectRequest("web");
+		assertThat(mavenPom(request)).doesNotContain("io.github.deweyjose");
+	}
+
+	@Test
+	void gradleBuildAddsDgsCodegenPlugin() {
+		ProjectRequest projectRequest = createProjectRequest("dgs-codegen");
+		assertThat(gradleBuild(projectRequest)).contains("id 'com.netflix.dgs.codegen' version '");
+	}
+
+	@Test
+	void gradleBuildConfiguresDgsCodegenPlugin() {
+		ProjectRequest projectRequest = createProjectRequest("dgs-codegen");
+		assertThat(gradleBuild(projectRequest)).containsSubsequence(
+		// @formatter:off
+				"generateJava {",
+				"	schemaPaths = [\"${projectDir}/src/main/resources/graphql-client\"]",
+				"	packageName = 'com.example.demo.codegen'",
+				"	generateClient = true",
+				"}"
+				// @formatter:on
+		);
+	}
+
+	@Test
+	void gradleKotlinDslBuildAddsDgsCodegenPlugin() {
+		ProjectRequest projectRequest = createProjectRequest("dgs-codegen");
+		assertThat(gradleKotlinDslBuild(projectRequest)).contains("id(\"com.netflix.dgs.codegen\") version ");
+	}
+
+	@Test
+	void gradleKotlinDslBuildConfiguresDgsCodegenPlugin() {
+		ProjectRequest projectRequest = createProjectRequest("dgs-codegen");
+		assertThat(gradleKotlinDslBuild(projectRequest)).containsSubsequence(
+		// @formatter:off
+				"tasks.generateJava {",
+				"	schemaPaths.add(\"${projectDir}/src/main/resources/graphql-client\")",
+				"	packageName = \"com.example.demo.codegen\"",
+				"	generateClient = true",
+				"}"
+				// @formatter:on
+		);
+	}
+
+	@Test
+	void mavenBuildConfiguresCodegenPlugin() {
+		ProjectRequest request = createProjectRequest("dgs-codegen");
+		assertThat(mavenPom(request)).lines().containsSequence(
+		// @formatter:off
+				"			<plugin>",
+				"				<groupId>io.github.deweyjose</groupId>",
+				"				<artifactId>graphqlcodegen-maven-plugin</artifactId>",
+				"				<version>1.50</version>",
+				"				<executions>",
+				"					<execution>",
+				"						<id>dgs-codegen</id>",
+				"						<goals>",
+				"							<goal>generate</goal>",
+				"						</goals>",
+				"						<configuration>",
+				"							<schemaPaths>",
+				"								<param>src/main/resources/graphql-client</param>",
+				"							</schemaPaths>",
+				"							<packageName>com.example.demo.codegen</packageName>",
+				"							<addGeneratedAnnotation>true</addGeneratedAnnotation>",
+				"						</configuration>",
+				"					</execution>",
+				"				</executions>",
+				"			</plugin>"
+		);
+		// @formatter:on
+	}
+
+	@Test
+	void mavenBuildConfiguresMavenHelperPlugin() {
+		ProjectRequest request = createProjectRequest("dgs-codegen");
+		assertThat(mavenPom(request)).lines().containsSequence(
+		// @formatter:off
+				"			<plugin>",
+				"				<groupId>org.codehaus.mojo</groupId>",
+				"				<artifactId>build-helper-maven-plugin</artifactId>",
+				"				<executions>",
+				"					<execution>",
+				"						<id>add-dgs-source</id>",
+				"						<phase>generate-sources</phase>",
+				"						<goals>",
+				"							<goal>add-source</goal>",
+				"						</goals>",
+				"						<configuration>",
+				"							<sources>",
+				"								<source>${project.build.directory}/generated-sources</source>",
+				"							</sources>",
+				"						</configuration>",
+				"					</execution>",
+				"				</executions>",
+				"			</plugin>"
+		);
+		// @formatter:on
+	}
+
+}


### PR DESCRIPTION
This commit adds a new dependency to start.spring.io, the "Netflix Data
Graph Service Codegen". This will not add a dependency to generated
project, but rather configure a Maven or a Gradle plugin in the build.

This Codegen plugin parses GraphQL schema files describing remote
GraphQL APIs and generates Java classes to easily create queries and
deserialize GraphQL responses.

<!--
Thanks for contributing to start.spring.io Please review the following notes before
submitting you pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Proposal for New Entries

STOP! If your contribution suggests the addition of a new entry, please do not submit it
Rather create a "New Entry Proposal" issue as we need some information from you before
proceeding.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
