### PR TITLE
Use Oracle Free rather than Oracle XE with Spring Boot 3.2.0 and later

### DIFF
--- a/start-site/src/main/java/io/spring/start/site/container/SimpleDockerServiceResolver.java
+++ b/start-site/src/main/java/io/spring/start/site/container/SimpleDockerServiceResolver.java
@@ -91,8 +91,8 @@ public class SimpleDockerServiceResolver implements DockerServiceResolver {
 	}
 
 	private static DockerService oracle() {
-		return DockerService.withImageAndTag("gvenzl/oracle-xe")
-			.website("https://hub.docker.com/r/gvenzl/oracle-xe")
+		return DockerService.withImageAndTag("gvenzl/oracle-free")
+			.website("https://hub.docker.com/r/gvenzl/oracle-free")
 			.ports(1521)
 			.build();
 	}

--- a/start-site/src/main/java/io/spring/start/site/extension/dependency/testcontainers/TestcontainersModuleRegistry.java
+++ b/start-site/src/main/java/io/spring/start/site/extension/dependency/testcontainers/TestcontainersModuleRegistry.java
@@ -67,8 +67,8 @@ abstract class TestcontainersModuleRegistry {
 					.customizeHelpDocument(addReferenceLink("MariaDB Module", "databases/mariadb/")),
 				onDependencies("mysql").customizeBuild(addModule("mysql"))
 					.customizeHelpDocument(addReferenceLink("MySQL Module", "databases/mysql/")),
-				onDependencies("oracle").customizeBuild(addModule("oracle-xe"))
-					.customizeHelpDocument(addReferenceLink("Oracle-XE Module", "databases/oraclexe/")),
+				onDependencies("oracle").customizeBuild(addModule("oracle-free"))
+					.customizeHelpDocument(addReferenceLink("Oracle Free Module", "databases/oraclefree/")),
 				onDependencies("postgresql").customizeBuild(addModule("postgresql"))
 					.customizeHelpDocument(addReferenceLink("Postgres Module", "databases/postgres/")),
 				onDependencies("pulsar", "pulsar-reactive").customizeBuild(addModule("pulsar"))

--- a/start-site/src/test/java/io/spring/start/site/extension/dependency/testcontainers/TestcontainersProjectGenerationConfigurationTests.java
+++ b/start-site/src/test/java/io/spring/start/site/extension/dependency/testcontainers/TestcontainersProjectGenerationConfigurationTests.java
@@ -70,7 +70,7 @@ class TestcontainersProjectGenerationConfigurationTests extends AbstractExtensio
 				Arguments.arguments("db2", "db2"), Arguments.arguments("kafka", "kafka"),
 				Arguments.arguments("kafka-streams", "kafka"), Arguments.arguments("mariadb", "mariadb"),
 				Arguments.arguments("mysql", "mysql"), Arguments.arguments("postgresql", "postgresql"),
-				Arguments.arguments("oracle", "oracle-xe"), Arguments.arguments("pulsar", "pulsar"),
+				Arguments.arguments("oracle", "oracle-free"), Arguments.arguments("pulsar", "pulsar"),
 				Arguments.arguments("pulsar-reactive", "pulsar"), Arguments.arguments("solace", "solace"),
 				Arguments.arguments("sqlserver", "mssqlserver"));
 	}
@@ -104,7 +104,7 @@ class TestcontainersProjectGenerationConfigurationTests extends AbstractExtensio
 				Arguments.arguments("data-r2dbc", "databases/r2dbc/"), Arguments.arguments("db2", "databases/db2"),
 				Arguments.arguments("kafka", "kafka/"), Arguments.arguments("kafka-streams", "kafka/"),
 				Arguments.arguments("mariadb", "databases/mariadb/"), Arguments.arguments("mysql", "databases/mysql/"),
-				Arguments.arguments("oracle", "databases/oraclexe/"),
+				Arguments.arguments("oracle", "databases/oraclefree/"),
 				Arguments.arguments("postgresql", "databases/postgres/"), Arguments.arguments("pulsar", "pulsar/"),
 				Arguments.arguments("pulsar-reactive", "pulsar/"), Arguments.arguments("solace", "solace/"),
 				Arguments.arguments("sqlserver", "databases/mssqlserver/"));

--- a/start-site/src/test/resources/compose/oracle.yaml
+++ b/start-site/src/test/resources/compose/oracle.yaml
@@ -1,6 +1,6 @@
 services:
   oracle:
-    image: 'gvenzl/oracle-xe:latest'
+    image: 'gvenzl/oracle-free:latest'
     environment:
       - 'ORACLE_PASSWORD=secret'
     ports:


### PR DESCRIPTION
Hi Spring team,

This PR upgrades the Testcontainer Oracle module from the [Oracle XE module](https://testcontainers.com/modules/oracle-xe/) to the new [Oracle Free module](https://testcontainers.com/modules/oracle-free/). [Oracle Database Free is the successor of Oracle XE](https://blogs.oracle.com/database/post/database-23c-free-ga) and the Oracle Free docker image as well as the Oracle Free Testcontainers modules are upward compatible.

Also adding @eddumelendez from the TC team.