### PR TITLE
Rename "Google Cloud Platform" to "Google Cloud"

### DIFF
--- a/start-site/src/main/resources/application.yml
+++ b/start-site/src/main/resources/application.yml
@@ -1358,7 +1358,7 @@ initializr:
             - rel: sample
               href: https://aka.ms/spring/samples/latest/storage
               description: Azure Storage Sample
-    - name: Google Cloud Platform
+    - name: Google Cloud
       bom: spring-cloud-gcp
       compatibilityRange: "[3.0.0,3.2.0-M1)"
       content:


### PR DESCRIPTION
Google Cloud Platform is now called Google Cloud

https://cloud.google.com/blog/topics/developers-practitioners/introducing-new-homepage-google-cloud - To further simplify your experience and ensure consistency across our products, Google Cloud Platform is now called Google Cloud.