### PR TITLE
Use ojdbc11 instead of ojdbc8

### DIFF
--- a/start-site/src/main/resources/application.yml
+++ b/start-site/src/main/resources/application.yml
@@ -588,7 +588,7 @@ initializr:
           id: oracle
           description: A JDBC driver that provides access to Oracle.
           groupId: com.oracle.database.jdbc
-          artifactId: ojdbc8
+          artifactId: ojdbc11
           scope: runtime
           starter: false
         - name: PostgreSQL Driver


### PR DESCRIPTION
Oracle provides multiple variants of their jdbc driver and connection pool, each targeting a different JDK baseline.

From https://www.oracle.com/database/technologies/maven-central-guide.html#DIY

ojdbc8: Supports JDBC 4.2 spec and for use with JDK8 and JDK11
ojdbc11: Supports JDBC 4.3 spec and for use with JDK11 and JDK17

Since JDK8 is no longer available on start.spring.io, we should move on to ojdbc11.

See https://github.com/spring-projects/spring-boot/pull/38654