### PR TITLE
Move Pulsar container to 'latest' tag

### DIFF
--- a/start-site/src/main/java/io/spring/start/site/container/SimpleDockerServiceResolver.java
+++ b/start-site/src/main/java/io/spring/start/site/container/SimpleDockerServiceResolver.java
@@ -113,8 +113,7 @@ public class SimpleDockerServiceResolver implements DockerServiceResolver {
 	}
 
 	private static DockerService pulsar() {
-		// The latest tag they provide is not the 'latest' GA
-		return DockerService.withImageAndTag("apachepulsar/pulsar:3.1.1")
+		return DockerService.withImageAndTag("apachepulsar/pulsar")
 			.website("https://hub.docker.com/r/apachepulsar/pulsar")
 			.command("bin/pulsar standalone")
 			.ports(8080, 6650)

--- a/start-site/src/main/java/io/spring/start/site/container/SimpleDockerServiceResolver.java
+++ b/start-site/src/main/java/io/spring/start/site/container/SimpleDockerServiceResolver.java
@@ -114,7 +114,7 @@ public class SimpleDockerServiceResolver implements DockerServiceResolver {
 
 	private static DockerService pulsar() {
 		// The latest tag they provide is not the 'latest' GA
-		return DockerService.withImageAndTag("apachepulsar/pulsar:3.1.0")
+		return DockerService.withImageAndTag("apachepulsar/pulsar:3.1.1")
 			.website("https://hub.docker.com/r/apachepulsar/pulsar")
 			.command("bin/pulsar standalone")
 			.ports(8080, 6650)

--- a/start-site/src/test/java/io/spring/start/site/extension/dependency/springpulsar/SpringPulsarProjectGenerationConfigurationTests.java
+++ b/start-site/src/test/java/io/spring/start/site/extension/dependency/springpulsar/SpringPulsarProjectGenerationConfigurationTests.java
@@ -172,7 +172,7 @@ class SpringPulsarProjectGenerationConfigurationTests extends AbstractExtensionT
 				assertThat(connection.containerClassNameGeneric()).isFalse();
 				assertThat(connection.dockerService()).satisfies((dockerService) -> {
 					assertThat(dockerService.getImage()).isEqualTo("apachepulsar/pulsar");
-					assertThat(dockerService.getImageTag()).isEqualTo("3.1.1");
+					assertThat(dockerService.getImageTag()).isEqualTo("latest");
 					assertThat(dockerService.getWebsite()).isEqualTo("https://hub.docker.com/r/apachepulsar/pulsar");
 					assertThat(dockerService.getCommand()).isEqualTo("bin/pulsar standalone");
 					assertThat(dockerService.getPorts()).containsExactlyInAnyOrder(8080, 6650);

--- a/start-site/src/test/java/io/spring/start/site/extension/dependency/springpulsar/SpringPulsarProjectGenerationConfigurationTests.java
+++ b/start-site/src/test/java/io/spring/start/site/extension/dependency/springpulsar/SpringPulsarProjectGenerationConfigurationTests.java
@@ -172,7 +172,7 @@ class SpringPulsarProjectGenerationConfigurationTests extends AbstractExtensionT
 				assertThat(connection.containerClassNameGeneric()).isFalse();
 				assertThat(connection.dockerService()).satisfies((dockerService) -> {
 					assertThat(dockerService.getImage()).isEqualTo("apachepulsar/pulsar");
-					assertThat(dockerService.getImageTag()).isEqualTo("3.1.0");
+					assertThat(dockerService.getImageTag()).isEqualTo("3.1.1");
 					assertThat(dockerService.getWebsite()).isEqualTo("https://hub.docker.com/r/apachepulsar/pulsar");
 					assertThat(dockerService.getCommand()).isEqualTo("bin/pulsar standalone");
 					assertThat(dockerService.getPorts()).containsExactlyInAnyOrder(8080, 6650);

--- a/start-site/src/test/resources/compose/pulsar.yaml
+++ b/start-site/src/test/resources/compose/pulsar.yaml
@@ -1,6 +1,6 @@
 services:
   pulsar:
-    image: 'apachepulsar/pulsar:3.1.1'
+    image: 'apachepulsar/pulsar:latest'
     ports:
       - '6650'
       - '8080'

--- a/start-site/src/test/resources/compose/pulsar.yaml
+++ b/start-site/src/test/resources/compose/pulsar.yaml
@@ -1,6 +1,6 @@
 services:
   pulsar:
-    image: 'apachepulsar/pulsar:3.1.0'
+    image: 'apachepulsar/pulsar:3.1.1'
     ports:
       - '6650'
       - '8080'


### PR DESCRIPTION
This commit updates the Pulsar Docker container version from `3.1.0` to `3.1.1` for both the Docker Compose file and the Testcontainers generated container definition.

For reference, Spring Boot uses [3.1.1](https://github.com/spring-projects/spring-boot/blob/b62b6d56c180cd0fba140fc7a73bfe2d691bea6c/spring-boot-project/spring-boot-dependencies/build.gradle#L1140) for its recommended version.