### PR TITLE
Fix package name for the "Oracle Free" Testcontainers module

### DIFF
--- a/start-site/src/main/java/io/spring/start/site/extension/dependency/oracle/OracleProjectGenerationConfiguration.java
+++ b/start-site/src/main/java/io/spring/start/site/extension/dependency/oracle/OracleProjectGenerationConfiguration.java
@@ -60,7 +60,7 @@ class OracleProjectGenerationConfiguration {
 
 	private enum OracleContainer {
 
-		FREE("oracleFree", "org.testcontainers.containers.oracle.OracleContainer"),
+		FREE("oracleFree", "org.testcontainers.oracle.OracleContainer"),
 
 		XE("oracleXe", "org.testcontainers.containers.OracleContainer");
 

--- a/start-site/src/test/java/io/spring/start/site/extension/dependency/oracle/OracleProjectGenerationConfigurationTests.java
+++ b/start-site/src/test/java/io/spring/start/site/extension/dependency/oracle/OracleProjectGenerationConfigurationTests.java
@@ -69,7 +69,7 @@ class OracleProjectGenerationConfigurationTests extends AbstractExtensionTests {
 		request.setBootVersion("3.2.0");
 		request.setLanguage("java");
 		assertThat(generateProject(request)).textFile("src/test/java/com/example/demo/TestDemoApplication.java")
-			.contains("import org.testcontainers.containers.oracle.OracleContainer;")
+			.contains("import org.testcontainers.oracle.OracleContainer;")
 			.contains("		return new OracleContainer(DockerImageName.parse(\"gvenzl/oracle-free:latest\"));");
 	}
 


### PR DESCRIPTION
Fixed a package name for the `OracleContainer` class, when using `oracle-free` Testcontainers module.

See
 - Commit to add "Oracle Free" module - https://github.com/testcontainers/testcontainers-java/commit/fa23ae4caac41c672710c6b5c3b6e2f3d70e82ea
 - `OracleContainer` class source code - https://github.com/testcontainers/testcontainers-java/blob/10ecdcee8eeb5ec3d9bc841c642b25f3823cb4e8/modules/oracle-free/src/main/java/org/testcontainers/oracle/OracleContainer.java

Otherwise, after generating a project on https://start.spring.io when selecting Spring Boot >= 3.2.0 + Oracle JDBC driver + Testcontainers results in code generated with incorrect imports, and compilation error.