### PR TITLE
Bump Sentry to `7.3.0`

### DIFF
--- a/start-site/src/main/resources/application.yml
+++ b/start-site/src/main/resources/application.yml
@@ -57,8 +57,8 @@ initializr:
         artifactId: sentry-bom
         versionProperty: sentry.version
         mappings:
-          - compatibilityRange: "[2.7.0,3.2.0-M1)"
-            version: 6.28.0
+          - compatibilityRange: "[2.7.0,3.3.0-M1)"
+            version: 7.3.0
       solace-spring-boot:
         groupId: com.solace.spring.boot
         artifactId: solace-spring-boot-bom
@@ -939,7 +939,7 @@ initializr:
           id: sentry
           bom: sentry
           description: Application performance monitoring and error tracking that help software teams see clearer, solve quicker, and learn continuously.
-          compatibilityRange: "[3.0.0,3.2.0-M1)"
+          compatibilityRange: "[3.0.0,3.3.0-M1)"
           groupId: io.sentry
           artifactId: sentry-spring-boot-starter-jakarta
           links:


### PR DESCRIPTION
Bumping Sentry to [`7.3.0`](https://github.com/getsentry/sentry-java/releases/tag/7.3.0) and change compatibility with Spring Versions.

I've tested compatibility with Spring Boot `3.2.2` and `3.3.0-M1` manually using our sample and also using a project generated via a locally spun up start.spring.io server.

<!--
Thanks for contributing to start.spring.io Please review the following notes before
submitting you pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Proposal for New Entries

STOP! If your contribution suggests the addition of a new entry, please do not submit it
Rather create a "New Entry Proposal" issue as we need some information from you before
proceeding.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
