### PR TITLE
Upgrade Timefold Solver to 1.7.0

### DIFF
--- a/start-site/src/main/resources/application.yml
+++ b/start-site/src/main/resources/application.yml
@@ -145,7 +145,7 @@ initializr:
         versionProperty: timefold-solver.version
         mappings:
           - compatibilityRange: "[3.0.0,3.3.0-M1)"
-            version: 1.6.0
+            version: 1.7.0
       vaadin:
         groupId: com.vaadin
         artifactId: vaadin-bom


### PR DESCRIPTION
A new version is out. Please let me know if there's anything wrong with this PR, and thank you for your time.