### PR TITLE
Add Spring AI starters

### DIFF
--- a/start-site/src/main/resources/application.yml
+++ b/start-site/src/main/resources/application.yml
@@ -85,6 +85,7 @@ initializr:
         mappings:
           - compatibilityRange: "[3.0.0,3.3.0-M1)"
             version: 0.8.0
+            repositories: spring-milestones
       spring-cloud:
         groupId: org.springframework.cloud
         artifactId: spring-cloud-dependencies

--- a/start-site/src/main/resources/application.yml
+++ b/start-site/src/main/resources/application.yml
@@ -1426,163 +1426,179 @@ initializr:
               href: https://github.com/GoogleCloudPlatform/spring-cloud-gcp/tree/main/spring-cloud-gcp-samples/spring-cloud-gcp-storage-resource-sample
     - name: AI
       content:
-        - name: Spring AI for Azure OpenAI
+        - name: Azure OpenAI
           id: spring-ai-azure-openai
           compatibility-range: "[3.1.0,3.3.0-M1)"
           group-id: org.springframework.ai
           artifact-id: spring-ai-azure-openai-spring-boot-starter
-          description: Azure’s OpenAI offering, powered by ChatGPT, extends beyond traditional OpenAI capabilities, delivering AI-driven text generation with enhanced functionality.
+          description: Spring AI support for Azure’s OpenAI offering, powered by ChatGPT. It extends beyond traditional OpenAI capabilities, delivering AI-driven text generation with enhanced functionality.
           bom: spring-ai
+          starter: true
           links:
             - rel: reference
               href: https://docs.spring.io/spring-ai/reference/api/clients/azure-openai-chat.html
-        - name: Spring AI vector database for Azure
+        - name: Azure AI Search
           id: spring-ai-vectordb-azure
           compatibility-range: "[3.1.0,3.3.0-M1)"
           group-id: org.springframework.ai
           artifact-id: spring-ai-azure-vector-store-spring-boot-starter
-          description: Azure AI Search is a versatile cloud-hosted cloud information retrieval system that is part of Microsoft’s larger AI platform. Among other features, it allows users to query information using vector-based storage and retrieval.
+          description: Spring AI support for Azure AI Search. It is an AI-powered information retrieval platform and part of Microsoft’s larger AI platform. Among other features, it allows users to query information using vector-based storage and retrieval.
           bom: spring-ai
+          starter: true
           links:
             - rel: reference
               href: https://docs.spring.io/spring-ai/reference/api/vectordbs/azure.html
-        - name: Spring AI for Amazon Bedrock
+        - name: Amazon Bedrock
           id: spring-ai-bedrock
           compatibility-range: "[3.1.0,3.3.0-M1)"
           group-id: org.springframework.ai
           artifact-id: spring-ai-bedrock-ai-spring-boot-starter
-          description: Amazon Bedrock is a managed service that provides foundation models from various AI providers, available through a unified API.
+          description: Spring AI support for Amazon Bedrock. It is a managed service that provides foundation models from various AI providers, available through a unified API.
           bom: spring-ai
+          starter: true
           links:
             - rel: reference
               href: https://docs.spring.io/spring-ai/reference/api/bedrock-chat.html
-        - name: Spring AI vector database for Chroma
+        - name: Chroma
           id: spring-ai-vectordb-chroma
           compatibility-range: "[3.1.0,3.3.0-M1)"
           group-id: org.springframework.ai
           artifact-id: spring-ai-chroma-store-spring-boot-starter
-          description: Chroma is the open-source embedding database. It gives you the tools to store document embeddings, content, and metadata and to search through those embeddings, including metadata filtering.
+          description: Spring AI support for Chroma. It is an open-source embedding database and gives you the tools to store document embeddings, content, and metadata. It also allows to search through those embeddings, including metadata filtering.
           bom: spring-ai
+          starter: true
           links:
             - rel: reference
               href: https://docs.spring.io/spring-ai/reference/api/vectordbs/chroma.html
-        - name: Spring AI vector database for Milvus
+        - name: Milvus
           id: spring-ai-vectordb-milvus
           compatibility-range: "[3.1.0,3.3.0-M1)"
           group-id: org.springframework.ai
           artifact-id: spring-ai-milvus-store-spring-boot-starter
-          description: Milvus is an open-source vector database that has garnered significant attention in the fields of data science and machine learning. One of its standout features lies in its robust support for vector indexing and querying.
+          description: Spring AI support for Milvus. It is an open-source vector database that has garnered significant attention in the fields of data science and machine learning. One of its standout features lies in its robust support for vector indexing and querying.
           bom: spring-ai
+          starter: true
           links:
             - rel: reference
               href: https://docs.spring.io/spring-ai/reference/api/vectordbs/milvus.html
-        - name: Spring AI vector database for Neo4J
+        - name: Neo4J Vector Search
           id: spring-ai-vectordb-neo4j
           compatibility-range: "[3.1.0,3.3.0-M1)"
           group-id: org.springframework.ai
           artifact-id: spring-ai-neo4j-store-spring-boot-starter
-          description: The Neo4j’s Vector Search allows users to query vector embeddings from large datasets.
+          description: Spring AI support for Neo4j's Vector Search. It allows users to query vector embeddings from large datasets.
           bom: spring-ai
+          starter: true
           links:
             - rel: reference
               href: https://docs.spring.io/spring-ai/reference/api/vectordbs/neo4j.html
-        - name: Spring AI for Ollama
+        - name: Ollama
           id: spring-ai-ollama
           compatibility-range: "[3.1.0,3.3.0-M1)"
           group-id: org.springframework.ai
           artifact-id: spring-ai-ollama-spring-boot-starter
-          description: With Ollama you can run various Large Language Models (LLMs) locally and generate text from them.
+          description: Spring AI support for Ollama. It allows you to run various Large Language Models (LLMs) locally and generate text from them.
           bom: spring-ai
+          starter: true
           links:
             - rel: reference
               href: https://docs.spring.io/spring-ai/reference/api/clients/ollama-chat.html
-        - name: Spring AI for OpenAI
+        - name: OpenAI
           id: spring-ai-openai
           compatibility-range: "[3.1.0,3.3.0-M1)"
           group-id: org.springframework.ai
           artifact-id: spring-ai-openai-spring-boot-starter
-          description: Support for ChatGPT, the AI language model and DALL-E, the Image generation model from OpenAI.
+          description: Spring AI support for ChatGPT, the AI language model and DALL-E, the Image generation model from OpenAI.
           bom: spring-ai
+          starter: true
           links:
             - rel: reference
               href: https://docs.spring.io/spring-ai/reference/api/clients/openai-chat.html
-        - name: Spring AI vector database for PGvector
+        - name: PGvector
           id: spring-ai-vectordb-pgvector
           compatibility-range: "[3.1.0,3.3.0-M1)"
           group-id: org.springframework.ai
           artifact-id: spring-ai-pgvector-store-spring-boot-starter
-          description: PGvector is an open-source extension for PostgreSQL that enables storing and searching over machine learning-generated embeddings.
+          description: Spring AI support for PGvector. It is an open-source extension for PostgreSQL that enables storing and searching over machine learning-generated embeddings.
           bom: spring-ai
+          starter: true
           links:
             - rel: reference
               href: https://docs.spring.io/spring-ai/reference/api/vectordbs/pgvector.html
-        - name: Spring AI vector database for Pinecone
+        - name: Pinecone
           id: spring-ai-vectordb-pinecone
           compatibility-range: "[3.1.0,3.3.0-M1)"
           group-id: org.springframework.ai
           artifact-id: spring-ai-pinecone-store-spring-boot-starter
-          description: Pinecone is a popular cloud-based vector database, which allows you to store and search vectors efficiently.
+          description: Spring AI support for Pinecone. It is a popular cloud-based vector database and allows you to store and search vectors efficiently.
           bom: spring-ai
+          starter: true
           links:
             - rel: reference
               href: https://docs.spring.io/spring-ai/reference/api/vectordbs/pinecone.html
-        - name: Spring AI for PostgresML
+        - name: PostgresML
           id: spring-ai-postgresml
           compatibility-range: "[3.1.0,3.3.0-M1)"
           group-id: org.springframework.ai
           artifact-id: spring-ai-postgresml-spring-boot-starter
-          description: Support for the PostgresML text embeddings models.
+          description: Spring AI support for the PostgresML text embeddings models.
           bom: spring-ai
+          starter: true
           links:
             - rel: reference
               href: https://docs.spring.io/spring-ai/reference/api/embeddings/postgresml-embeddings.html
-        - name: Spring AI vector database for Redis
+        - name: Redis Search and Query Redis Search and Query
           id: spring-ai-vectordb-redis
           compatibility-range: "[3.1.0,3.3.0-M1)"
           group-id: org.springframework.ai
           artifact-id: spring-ai-redis-spring-boot-starter
-          description: Redis Search and Query extends the core features of Redis OSS and allows you to use Redis as a vector database.
+          description: Spring AI support for Redis Search and Query.It extends the core features of Redis OSS and allows you to use Redis as a vector database.
           bom: spring-ai
+          starter: true
           links:
             - rel: reference
               href: https://docs.spring.io/spring-ai/reference/api/vectordbs/redis.html
-        - name: Spring AI for Stability AI
+        - name: Stability AI
           id: spring-ai-stabilityai
           compatibility-range: "[3.1.0,3.3.0-M1)"
           group-id: org.springframework.ai
           artifact-id: spring-ai-stability-ai-spring-boot-starter
-          description: Support for Stability AI's text to image generation model.
+          description: Spring AI support for Stability AI's text to image generation model.
           bom: spring-ai
+          starter: true
           links:
             - rel: reference
               href: https://docs.spring.io/spring-ai/reference/api/clients/image/stabilityai-image.html
-        - name: Spring AI for Transformers (ONNX) Embeddings
+        - name: Transformers (ONNX) Embeddings
           id: spring-ai-transformers
           compatibility-range: "[3.1.0,3.3.0-M1)"
           group-id: org.springframework.ai
           artifact-id: spring-ai-transformers-spring-boot-starter
-          description: Support for pre-trained transformer models, serialized into the Open Neural Network Exchange (ONNX) format.
+          description: Spring AI support for pre-trained transformer models, serialized into the Open Neural Network Exchange (ONNX) format.
           bom: spring-ai
+          starter: true
           links:
             - rel: reference
               href: https://docs.spring.io/spring-ai/reference/api/embeddings/onnx.html
-        - name: Spring AI for Vertex AI
+        - name: Vertex AI
           id: spring-ai-vertexai
           compatibility-range: "[3.1.0,3.3.0-M1)"
           group-id: org.springframework.ai
           artifact-id: spring-ai-vertex-ai-spring-boot-starter
-          description: The Generative Language PaLM API allows developers to build generative AI applications using the PaLM model.
+          description: Spring AI support for Google Vertex PaLM chat and embedding models.
           bom: spring-ai
+          starter: true
           links:
             - rel: reference
               href: https://docs.spring.io/spring-ai/reference/api/clients/vertexai-chat.html
-        - name: Spring AI vector database for Weaviate
+        - name: Weaviate
           id: spring-ai-vectordb-weaviate
           compatibility-range: "[3.1.0,3.3.0-M1)"
           group-id: org.springframework.ai
           artifact-id: spring-ai-weaviate-store-spring-boot-starter
-          description: Weaviate is an open-source vector database. It allows you to store data objects and vector embeddings from your favorite ML-models and scale seamlessly into billions of data objects.
+          description: Spring AI support for Weaviate, an open-source vector database. It allows you to store data objects and vector embeddings from your favorite ML-models and scale seamlessly into billions of data objects.
           bom: spring-ai
+          starter: true
           links:
             - rel: reference
               href: https://docs.spring.io/spring-ai/reference/api/vectordbs/weaviate.html

--- a/start-site/src/main/resources/application.yml
+++ b/start-site/src/main/resources/application.yml
@@ -78,6 +78,16 @@ initializr:
             version: 3.0.0
           - compatibilityRange: "[3.1.0-M1, 3.3.0-M1)"
             version: 3.1.0
+      spring-ai:
+        groupId: org.springframework.ai
+        artifactId: spring-ai-bom
+        versionProperty: spring-ai.version
+        mappings:
+          - compatibilityRange: "[3.0.0,3.3.0-M1)"
+            # TODO: Replace with released version
+            version: 0.8.0-SNAPSHOT
+            # TODO: Remove once on Maven central
+            repositories: spring-snapshots
       spring-cloud:
         groupId: org.springframework.cloud
         artifactId: spring-cloud-dependencies
@@ -894,19 +904,6 @@ initializr:
           links:
             - rel: reference
               href: https://spring.io/projects/spring-shell
-        - name: Timefold Solver
-          id: timefold-solver
-          compatibilityRange: "[2.6.0,3.3.0-M1)"
-          groupId: ai.timefold.solver
-          artifactId: timefold-solver-spring-boot-starter
-          description: AI solver to optimize operations and scheduling.
-          bom: timefold-solver
-          links:
-            - rel: reference
-              href:  https://timefold.ai/docs/timefold-solver/latest/quickstart/spring-boot/spring-boot-quickstart#springBootJavaQuickStart
-            - rel: sample
-              href: https://github.com/TimefoldAI/timefold-quickstarts/tree/stable/technology/java-spring-boot
-              description: Timetabling sample. Assign lessons to timeslots and rooms to produce a better schedule for teachers and students
     - name: Ops
       content:
         - name: Spring Boot Actuator
@@ -1427,6 +1424,181 @@ initializr:
               href: https://googlecloudplatform.github.io/spring-cloud-gcp/reference/html/index.html#cloud-storage
             - rel: guide
               href: https://github.com/GoogleCloudPlatform/spring-cloud-gcp/tree/main/spring-cloud-gcp-samples/spring-cloud-gcp-storage-resource-sample
+    - name: AI
+      content:
+        - name: Spring AI for Azure OpenAI
+          id: spring-ai-azure-openai
+          compatibility-range: "[3.1.0,3.3.0-M1)"
+          group-id: org.springframework.ai
+          artifact-id: spring-ai-azure-openai-spring-boot-starter
+          description: Azure’s OpenAI offering, powered by ChatGPT, extends beyond traditional OpenAI capabilities, delivering AI-driven text generation with enhanced functionality.
+          bom: spring-ai
+          links:
+            - rel: reference
+              href: https://docs.spring.io/spring-ai/reference/api/clients/azure-openai-chat.html
+        - name: Spring AI vector database for Azure
+          id: spring-ai-vectordb-azure
+          compatibility-range: "[3.1.0,3.3.0-M1)"
+          group-id: org.springframework.ai
+          artifact-id: spring-ai-azure-vector-store-spring-boot-starter
+          description: Azure AI Search is a versatile cloud-hosted cloud information retrieval system that is part of Microsoft’s larger AI platform. Among other features, it allows users to query information using vector-based storage and retrieval.
+          bom: spring-ai
+          links:
+            - rel: reference
+              href: https://docs.spring.io/spring-ai/reference/api/vectordbs/azure.html
+        - name: Spring AI for Amazon Bedrock
+          id: spring-ai-bedrock
+          compatibility-range: "[3.1.0,3.3.0-M1)"
+          group-id: org.springframework.ai
+          artifact-id: spring-ai-bedrock-ai-spring-boot-starter
+          description: Amazon Bedrock is a managed service that provides foundation models from various AI providers, available through a unified API.
+          bom: spring-ai
+          links:
+            - rel: reference
+              href: https://docs.spring.io/spring-ai/reference/api/bedrock-chat.html
+        - name: Spring AI vector database for Chroma
+          id: spring-ai-vectordb-chroma
+          compatibility-range: "[3.1.0,3.3.0-M1)"
+          group-id: org.springframework.ai
+          artifact-id: spring-ai-chroma-store-spring-boot-starter
+          description: Chroma is the open-source embedding database. It gives you the tools to store document embeddings, content, and metadata and to search through those embeddings, including metadata filtering.
+          bom: spring-ai
+          links:
+            - rel: reference
+              href: https://docs.spring.io/spring-ai/reference/api/vectordbs/chroma.html
+        - name: Spring AI vector database for Milvus
+          id: spring-ai-vectordb-milvus
+          compatibility-range: "[3.1.0,3.3.0-M1)"
+          group-id: org.springframework.ai
+          artifact-id: spring-ai-milvus-store-spring-boot-starter
+          description: Milvus is an open-source vector database that has garnered significant attention in the fields of data science and machine learning. One of its standout features lies in its robust support for vector indexing and querying.
+          bom: spring-ai
+          links:
+            - rel: reference
+              href: https://docs.spring.io/spring-ai/reference/api/vectordbs/milvus.html
+        - name: Spring AI vector database for Neo4J
+          id: spring-ai-vectordb-neo4j
+          compatibility-range: "[3.1.0,3.3.0-M1)"
+          group-id: org.springframework.ai
+          artifact-id: spring-ai-neo4j-store-spring-boot-starter
+          description: The Neo4j’s Vector Search allows users to query vector embeddings from large datasets.
+          bom: spring-ai
+          links:
+            - rel: reference
+              href: https://docs.spring.io/spring-ai/reference/api/vectordbs/neo4j.html
+        - name: Spring AI for Ollama
+          id: spring-ai-ollama
+          compatibility-range: "[3.1.0,3.3.0-M1)"
+          group-id: org.springframework.ai
+          artifact-id: spring-ai-ollama-spring-boot-starter
+          description: With Ollama you can run various Large Language Models (LLMs) locally and generate text from them.
+          bom: spring-ai
+          links:
+            - rel: reference
+              href: https://docs.spring.io/spring-ai/reference/api/clients/ollama-chat.html
+        - name: Spring AI for OpenAI
+          id: spring-ai-openai
+          compatibility-range: "[3.1.0,3.3.0-M1)"
+          group-id: org.springframework.ai
+          artifact-id: spring-ai-openai-spring-boot-starter
+          description: Support for ChatGPT, the AI language model and DALL-E, the Image generation model from OpenAI.
+          bom: spring-ai
+          links:
+            - rel: reference
+              href: https://docs.spring.io/spring-ai/reference/api/clients/openai-chat.html
+        - name: Spring AI vector database for PGvector
+          id: spring-ai-vectordb-pgvector
+          compatibility-range: "[3.1.0,3.3.0-M1)"
+          group-id: org.springframework.ai
+          artifact-id: spring-ai-pgvector-store-spring-boot-starter
+          description: PGvector is an open-source extension for PostgreSQL that enables storing and searching over machine learning-generated embeddings.
+          bom: spring-ai
+          links:
+            - rel: reference
+              href: https://docs.spring.io/spring-ai/reference/api/vectordbs/pgvector.html
+        - name: Spring AI vector database for Pinecone
+          id: spring-ai-vectordb-pinecone
+          compatibility-range: "[3.1.0,3.3.0-M1)"
+          group-id: org.springframework.ai
+          artifact-id: spring-ai-pinecone-store-spring-boot-starter
+          description: Pinecone is a popular cloud-based vector database, which allows you to store and search vectors efficiently.
+          bom: spring-ai
+          links:
+            - rel: reference
+              href: https://docs.spring.io/spring-ai/reference/api/vectordbs/pinecone.html
+        - name: Spring AI for PostgresML
+          id: spring-ai-postgresml
+          compatibility-range: "[3.1.0,3.3.0-M1)"
+          group-id: org.springframework.ai
+          artifact-id: spring-ai-postgresml-spring-boot-starter
+          description: Support for the PostgresML text embeddings models.
+          bom: spring-ai
+          links:
+            - rel: reference
+              href: https://docs.spring.io/spring-ai/reference/api/embeddings/postgresml-embeddings.html
+        - name: Spring AI vector database for Redis
+          id: spring-ai-vectordb-redis
+          compatibility-range: "[3.1.0,3.3.0-M1)"
+          group-id: org.springframework.ai
+          artifact-id: spring-ai-redis-spring-boot-starter
+          description: Redis Search and Query extends the core features of Redis OSS and allows you to use Redis as a vector database.
+          bom: spring-ai
+          links:
+            - rel: reference
+              href: https://docs.spring.io/spring-ai/reference/api/vectordbs/redis.html
+        - name: Spring AI for Stability AI
+          id: spring-ai-stabilityai
+          compatibility-range: "[3.1.0,3.3.0-M1)"
+          group-id: org.springframework.ai
+          artifact-id: spring-ai-stability-ai-spring-boot-starter
+          description: Support for Stability AI's text to image generation model.
+          bom: spring-ai
+          links:
+            - rel: reference
+              href: https://docs.spring.io/spring-ai/reference/api/clients/image/stabilityai-image.html
+        - name: Spring AI for Transformers (ONNX) Embeddings
+          id: spring-ai-transformers
+          compatibility-range: "[3.1.0,3.3.0-M1)"
+          group-id: org.springframework.ai
+          artifact-id: spring-ai-transformers-spring-boot-starter
+          description: Support for pre-trained transformer models, serialized into the Open Neural Network Exchange (ONNX) format.
+          bom: spring-ai
+          links:
+            - rel: reference
+              href: https://docs.spring.io/spring-ai/reference/api/embeddings/onnx.html
+        - name: Spring AI for Vertex AI
+          id: spring-ai-vertexai
+          compatibility-range: "[3.1.0,3.3.0-M1)"
+          group-id: org.springframework.ai
+          artifact-id: spring-ai-vertex-ai-spring-boot-starter
+          description: The Generative Language PaLM API allows developers to build generative AI applications using the PaLM model.
+          bom: spring-ai
+          links:
+            - rel: reference
+              href: https://docs.spring.io/spring-ai/reference/api/clients/vertexai-chat.html
+        - name: Spring AI vector database for Weaviate
+          id: spring-ai-vectordb-weaviate
+          compatibility-range: "[3.1.0,3.3.0-M1)"
+          group-id: org.springframework.ai
+          artifact-id: spring-ai-weaviate-store-spring-boot-starter
+          description: Weaviate is an open-source vector database. It allows you to store data objects and vector embeddings from your favorite ML-models and scale seamlessly into billions of data objects.
+          bom: spring-ai
+          links:
+            - rel: reference
+              href: https://docs.spring.io/spring-ai/reference/api/vectordbs/weaviate.html
+        - name: Timefold Solver
+          id: timefold-solver
+          compatibilityRange: "[2.6.0,3.3.0-M1)"
+          groupId: ai.timefold.solver
+          artifactId: timefold-solver-spring-boot-starter
+          description: AI solver to optimize operations and scheduling.
+          bom: timefold-solver
+          links:
+            - rel: reference
+              href:  https://timefold.ai/docs/timefold-solver/latest/quickstart/spring-boot/spring-boot-quickstart#springBootJavaQuickStart
+            - rel: sample
+              href: https://github.com/TimefoldAI/timefold-quickstarts/tree/stable/technology/java-spring-boot
+              description: Timetabling sample. Assign lessons to timeslots and rooms to produce a better schedule for teachers and students
   types:
     - name: Gradle - Groovy
       id: gradle-project

--- a/start-site/src/main/resources/application.yml
+++ b/start-site/src/main/resources/application.yml
@@ -84,10 +84,7 @@ initializr:
         versionProperty: spring-ai.version
         mappings:
           - compatibilityRange: "[3.0.0,3.3.0-M1)"
-            # TODO: Replace with released version
-            version: 0.8.0-SNAPSHOT
-            # TODO: Remove once on Maven central
-            repositories: spring-snapshots
+            version: 0.8.0
       spring-cloud:
         groupId: org.springframework.cloud
         artifactId: spring-cloud-dependencies
@@ -1442,7 +1439,7 @@ initializr:
           compatibility-range: "[3.1.0,3.3.0-M1)"
           group-id: org.springframework.ai
           artifact-id: spring-ai-azure-vector-store-spring-boot-starter
-          description: Spring AI support for Azure AI Search. It is an AI-powered information retrieval platform and part of Microsoft’s larger AI platform. Among other features, it allows users to query information using vector-based storage and retrieval.
+          description: Spring AI vector database support for Azure AI Search. It is an AI-powered information retrieval platform and part of Microsoft’s larger AI platform. Among other features, it allows users to query information using vector-based storage and retrieval.
           bom: spring-ai
           starter: true
           links:
@@ -1459,34 +1456,34 @@ initializr:
           links:
             - rel: reference
               href: https://docs.spring.io/spring-ai/reference/api/bedrock-chat.html
-        - name: Chroma
+        - name: Chroma Vector Database
           id: spring-ai-vectordb-chroma
           compatibility-range: "[3.1.0,3.3.0-M1)"
           group-id: org.springframework.ai
           artifact-id: spring-ai-chroma-store-spring-boot-starter
-          description: Spring AI support for Chroma. It is an open-source embedding database and gives you the tools to store document embeddings, content, and metadata. It also allows to search through those embeddings, including metadata filtering.
+          description: Spring AI vector database support for Chroma. It is an open-source embedding database and gives you the tools to store document embeddings, content, and metadata. It also allows to search through those embeddings, including metadata filtering.
           bom: spring-ai
           starter: true
           links:
             - rel: reference
               href: https://docs.spring.io/spring-ai/reference/api/vectordbs/chroma.html
-        - name: Milvus
+        - name: Milvus Vector Database
           id: spring-ai-vectordb-milvus
           compatibility-range: "[3.1.0,3.3.0-M1)"
           group-id: org.springframework.ai
           artifact-id: spring-ai-milvus-store-spring-boot-starter
-          description: Spring AI support for Milvus. It is an open-source vector database that has garnered significant attention in the fields of data science and machine learning. One of its standout features lies in its robust support for vector indexing and querying.
+          description: Spring AI vector database support for Milvus. It is an open-source vector database that has garnered significant attention in the fields of data science and machine learning. One of its standout features lies in its robust support for vector indexing and querying.
           bom: spring-ai
           starter: true
           links:
             - rel: reference
               href: https://docs.spring.io/spring-ai/reference/api/vectordbs/milvus.html
-        - name: Neo4J Vector Search
+        - name: Neo4J Vector Database
           id: spring-ai-vectordb-neo4j
           compatibility-range: "[3.1.0,3.3.0-M1)"
           group-id: org.springframework.ai
           artifact-id: spring-ai-neo4j-store-spring-boot-starter
-          description: Spring AI support for Neo4j's Vector Search. It allows users to query vector embeddings from large datasets.
+          description: Spring AI vector database support for Neo4j's Vector Search. It allows users to query vector embeddings from large datasets.
           bom: spring-ai
           starter: true
           links:
@@ -1514,23 +1511,23 @@ initializr:
           links:
             - rel: reference
               href: https://docs.spring.io/spring-ai/reference/api/clients/openai-chat.html
-        - name: PGvector
+        - name: PGvector Vector Database
           id: spring-ai-vectordb-pgvector
           compatibility-range: "[3.1.0,3.3.0-M1)"
           group-id: org.springframework.ai
           artifact-id: spring-ai-pgvector-store-spring-boot-starter
-          description: Spring AI support for PGvector. It is an open-source extension for PostgreSQL that enables storing and searching over machine learning-generated embeddings.
+          description: Spring AI vector database support for PGvector. It is an open-source extension for PostgreSQL that enables storing and searching over machine learning-generated embeddings.
           bom: spring-ai
           starter: true
           links:
             - rel: reference
               href: https://docs.spring.io/spring-ai/reference/api/vectordbs/pgvector.html
-        - name: Pinecone
+        - name: Pinecone Vector Database
           id: spring-ai-vectordb-pinecone
           compatibility-range: "[3.1.0,3.3.0-M1)"
           group-id: org.springframework.ai
           artifact-id: spring-ai-pinecone-store-spring-boot-starter
-          description: Spring AI support for Pinecone. It is a popular cloud-based vector database and allows you to store and search vectors efficiently.
+          description: Spring AI vector database support for Pinecone. It is a popular cloud-based vector database and allows you to store and search vectors efficiently.
           bom: spring-ai
           starter: true
           links:
@@ -1547,12 +1544,12 @@ initializr:
           links:
             - rel: reference
               href: https://docs.spring.io/spring-ai/reference/api/embeddings/postgresml-embeddings.html
-        - name: Redis Search and Query
+        - name: Redis Search and Query Vector Database
           id: spring-ai-vectordb-redis
           compatibility-range: "[3.1.0,3.3.0-M1)"
           group-id: org.springframework.ai
           artifact-id: spring-ai-redis-spring-boot-starter
-          description: Spring AI support for Redis Search and Query.It extends the core features of Redis OSS and allows you to use Redis as a vector database.
+          description: Spring AI vector database support for Redis Search and Query.It extends the core features of Redis OSS and allows you to use Redis as a vector database.
           bom: spring-ai
           starter: true
           links:
@@ -1591,12 +1588,12 @@ initializr:
           links:
             - rel: reference
               href: https://docs.spring.io/spring-ai/reference/api/clients/vertexai-chat.html
-        - name: Weaviate
+        - name: Weaviate Vector Database
           id: spring-ai-vectordb-weaviate
           compatibility-range: "[3.1.0,3.3.0-M1)"
           group-id: org.springframework.ai
           artifact-id: spring-ai-weaviate-store-spring-boot-starter
-          description: Spring AI support for Weaviate, an open-source vector database. It allows you to store data objects and vector embeddings from your favorite ML-models and scale seamlessly into billions of data objects.
+          description: Spring AI vector database support for Weaviate, an open-source vector database. It allows you to store data objects and vector embeddings from your favorite ML-models and scale seamlessly into billions of data objects.
           bom: spring-ai
           starter: true
           links:

--- a/start-site/src/main/resources/application.yml
+++ b/start-site/src/main/resources/application.yml
@@ -1547,7 +1547,7 @@ initializr:
           links:
             - rel: reference
               href: https://docs.spring.io/spring-ai/reference/api/embeddings/postgresml-embeddings.html
-        - name: Redis Search and Query Redis Search and Query
+        - name: Redis Search and Query
           id: spring-ai-vectordb-redis
           compatibility-range: "[3.1.0,3.3.0-M1)"
           group-id: org.springframework.ai


### PR DESCRIPTION
This adds all 16 starters for Spring AI to the site.

I think most are fine, the ones I'm not totally happy with are Redis, Postgres and neo4j. If a user wants to use Neo4J, redis or postgres, they now get AI components suggested.