### PR TITLE
Fix link to Spring Modulith reference.

### DIFF
--- a/start-site/src/main/resources/application.yml
+++ b/start-site/src/main/resources/application.yml
@@ -223,7 +223,7 @@ initializr:
           description: Support for building modular monolithic applications.
           links:
             - rel: reference
-              href: https://docs.spring.io/spring-modulith/docs/current/reference/html/
+              href: https://docs.spring.io/spring-modulith/reference/
     - name: Web
       content:
         - name: Spring Web


### PR DESCRIPTION
<!--
Thanks for contributing to start.spring.io Please review the following notes before
submitting you pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Proposal for New Entries

STOP! If your contribution suggests the addition of a new entry, please do not submit it
Rather create a "New Entry Proposal" issue as we need some information from you before
proceeding.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
Changed a link to Spring Modulith that appears in `HELP.md` file from https://docs.spring.io/spring-modulith/docs/current/reference/html/ to https://docs.spring.io/spring-modulith/reference/ as the former results in `Page Not Found`.