### PR TITLE
Upgrade compatibility range for Vaadin

### DIFF
--- a/start-site/src/main/resources/application.yml
+++ b/start-site/src/main/resources/application.yml
@@ -171,7 +171,7 @@ initializr:
         artifactId: vaadin-bom
         versionProperty: vaadin.version
         mappings:
-          - compatibilityRange: "[3.0.0,3.3.0-M1)"
+          - compatibilityRange: "[3.0.0,3.4.0-M1)"
             version: 24.3.12
     gradle:
       dependency-management-plugin-version: 1.0.14.RELEASE
@@ -355,7 +355,7 @@ initializr:
           artifactId: vaadin-spring-boot-starter
           description: A web framework that allows you to write UI in pure Java without getting bogged down in JS, HTML, and CSS.
           bom: vaadin
-          compatibilityRange: "[3.0.0,3.3.0-M1)"
+          compatibilityRange: "[3.0.0,3.4.0-M1)"
           links:
             - rel: guide
               href: https://spring.io/guides/gs/crud-with-vaadin/


### PR DESCRIPTION
we have tested the new Spring-boot 3.3.0 on our product, which can confirm that it is compatible.  