### PR TITLE
Optimizations in Spring Modulith dependency setup causes BOM not being added

### DIFF
--- a/start-site/src/main/java/io/spring/start/site/extension/dependency/springmodulith/SpringModulithBuildCustomizer.java
+++ b/start-site/src/main/java/io/spring/start/site/extension/dependency/springmodulith/SpringModulithBuildCustomizer.java
@@ -51,10 +51,7 @@ class SpringModulithBuildCustomizer implements BuildCustomizer<Build> {
 			dependencies.add("modulith-observability",
 					modulithDependency("observability").scope(DependencyScope.RUNTIME));
 		}
-		boolean persistenceBackendAdded = addEventPublicationRegistryBackend(build);
-		if (persistenceBackendAdded) {
-			dependencies.remove("modulith");
-		}
+		addEventPublicationRegistryBackend(build);
 		dependencies.add("modulith-starter-test",
 				modulithDependency("starter-test").scope(DependencyScope.TEST_COMPILE));
 	}

--- a/start-site/src/test/java/io/spring/start/site/extension/dependency/springmodulith/SpringModulithBuildCustomizerTests.java
+++ b/start-site/src/test/java/io/spring/start/site/extension/dependency/springmodulith/SpringModulithBuildCustomizerTests.java
@@ -71,16 +71,7 @@ class SpringModulithBuildCustomizerTests extends AbstractExtensionTests {
 		build.dependencies().add("data-" + store);
 		this.customizer.customize(build);
 		assertThat(build.dependencies().ids()).contains("modulith-starter-" + store);
-		assertThat(build.dependencies().ids()).doesNotContain("modulith");
-	}
-
-	@ParameterizedTest
-	@ValueSource(strings = { "jdbc", "jpa", "mongodb" })
-	void presenceOfSpringDataModuleRemovesCoreStarter(String store) {
-		Build build = createBuild("modulith");
-		build.dependencies().add("data-" + store);
-		this.customizer.customize(build);
-		assertThat(build.dependencies().ids()).doesNotContain("modulith");
+		assertThat(build.dependencies().ids()).doesNotContain("modulith-starter-core");
 	}
 
 	private Build createBuild(String... dependencies) {


### PR DESCRIPTION
The removal of the core dependency causes the BOM not being added as that's contained in the dependency declaration. Manually adding the BOM (build.boms().add(…)) adds the BOM segment but does not declare the version property that's needed to resolve it properly.

<!--
Thanks for contributing to start.spring.io Please review the following notes before
submitting you pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Proposal for New Entries

STOP! If your contribution suggests the addition of a new entry, please do not submit it
Rather create a "New Entry Proposal" issue as we need some information from you before
proceeding.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
