### PR TITLE
Fix typo in Neo4j Vector database

### DIFF
--- a/start-site/src/main/resources/application.yml
+++ b/start-site/src/main/resources/application.yml
@@ -1463,7 +1463,7 @@ initializr:
           links:
             - rel: reference
               href: https://docs.spring.io/spring-ai/reference/api/clients/mistralai-chat.html
-        - name: Neo4J Vector Database
+        - name: Neo4j Vector Database
           id: spring-ai-vectordb-neo4j
           group-id: org.springframework.ai
           artifact-id: spring-ai-neo4j-store-spring-boot-starter


### PR DESCRIPTION
The product is spelled with a lower-case j