### PR TITLE
Automatically add Spring Modulith event externalization dependency

### DIFF
--- a/start-site/src/test/java/io/spring/start/site/extension/dependency/springmodulith/SpringModulithBuildCustomizerTests.java
+++ b/start-site/src/test/java/io/spring/start/site/extension/dependency/springmodulith/SpringModulithBuildCustomizerTests.java
@@ -74,6 +74,24 @@ class SpringModulithBuildCustomizerTests extends AbstractExtensionTests {
 		assertThat(build.dependencies().ids()).doesNotContain("modulith-starter-core");
 	}
 
+	@ParameterizedTest
+	@ValueSource(strings = { "amqp", "kafka" })
+	void addsExternalizationDependency(String broker) {
+		Build build = createBuild("modulith", broker);
+		this.customizer.customize(build);
+		assertThat(build.dependencies().ids()).contains("modulith-events-" + broker);
+		assertThat(build.dependencies().ids()).contains("modulith-events-api");
+	}
+
+	@ParameterizedTest
+	@ValueSource(strings = { "activemq", "artemis" })
+	void addsJmsExternalizationDependency(String broker) {
+		Build build = createBuild("modulith", broker);
+		this.customizer.customize(build);
+		assertThat(build.dependencies().ids()).contains("modulith-events-jms");
+		assertThat(build.dependencies().ids()).contains("modulith-events-api");
+	}
+
 	private Build createBuild(String... dependencies) {
 		InitializrMetadata metadata = getMetadata();
 		MavenBuild build = new MavenBuild(new MetadataBuildItemResolver(metadata, getDefaultPlatformVersion(metadata)));


### PR DESCRIPTION
If a message broker *and* Spring Modulith are declared as project dependencies, the event externalization of Spring Modulith for the configured broker is now declared automatically as well. Also, the Spring Modulith Events API dependency is declared in compile scope to allow event types to be marked for externalization.