### PR TITLE
Remove `addGeneratedAnnotation` from DGS Codegen Maven configuration

### DIFF
--- a/start-site/src/main/java/io/spring/start/site/extension/dependency/dgs/DgsCodegenMavenBuildCustomizer.java
+++ b/start-site/src/main/java/io/spring/start/site/extension/dependency/dgs/DgsCodegenMavenBuildCustomizer.java
@@ -48,8 +48,7 @@ public class DgsCodegenMavenBuildCustomizer implements BuildCustomizer<MavenBuil
 										.add("schemaPaths",
 												(schemaPaths) -> schemaPaths.add("param",
 														"src/main/resources/graphql-client"))
-										.add("packageName", this.packageName + ".codegen")
-										.add("addGeneratedAnnotation", "true"))));
+										.add("packageName", this.packageName + ".codegen"))));
 		build.plugins()
 			.add("org.codehaus.mojo", "build-helper-maven-plugin",
 					(plugin) -> plugin.execution("add-dgs-source", (execution) -> execution.goal("add-source")

--- a/start-site/src/test/java/io/spring/start/site/extension/dependency/dgs/DgsCodegenProjectGenerationConfigurationTests.java
+++ b/start-site/src/test/java/io/spring/start/site/extension/dependency/dgs/DgsCodegenProjectGenerationConfigurationTests.java
@@ -101,7 +101,6 @@ class DgsCodegenProjectGenerationConfigurationTests extends AbstractExtensionTes
 				"								<param>src/main/resources/graphql-client</param>",
 				"							</schemaPaths>",
 				"							<packageName>com.example.demo.codegen</packageName>",
-				"							<addGeneratedAnnotation>true</addGeneratedAnnotation>",
 				"						</configuration>",
 				"					</execution>",
 				"				</executions>",


### PR DESCRIPTION
This property adds a timestamp to the generated sources and provides little value.

The [default value of this property is `false` in the plugin](https://github.com/deweyjose/graphqlcodegen/blob/d02aed8d85e8f223e461a76372cbe556e76726fa/src/main/java/io/github/deweyjose/graphqlcodegen/Codegen.java#L149). 

This change also brings it more in line with Gradle which doesn't configure this property and [whose default value is also `false`](https://github.com/Netflix/dgs-codegen/blob/3bf84bc13af2e939979e53b76d760be6575a7638/graphql-dgs-codegen-gradle/src/main/kotlin/com/netflix/graphql/dgs/codegen/gradle/GenerateJavaTask.kt#L142).

<!--
Thanks for contributing to start.spring.io Please review the following notes before
submitting you pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Proposal for New Entries

STOP! If your contribution suggests the addition of a new entry, please do not submit it
Rather create a "New Entry Proposal" issue as we need some information from you before
proceeding.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
