### PR TITLE
Include the java plugin when adding org.hibernate.orm to the gradle build

### DIFF
--- a/start-site/src/main/java/io/spring/start/site/extension/dependency/graalvm/HibernatePluginGradleBuildCustomizer.java
+++ b/start-site/src/main/java/io/spring/start/site/extension/dependency/graalvm/HibernatePluginGradleBuildCustomizer.java
@@ -35,6 +35,7 @@ class HibernatePluginGradleBuildCustomizer implements BuildCustomizer<GradleBuil
 
 	@Override
 	public void customize(GradleBuild build) {
+		build.plugins().add("java");
 		build.plugins().add("org.hibernate.orm", (plugin) -> plugin.setVersion(this.hibernateVersion.toString()));
 		build.extensions()
 			.customize("hibernate", (hibernate) -> hibernate.nested("enhancement",

--- a/start-site/src/test/java/io/spring/start/site/extension/dependency/graalvm/HibernatePluginGradleBuildCustomizerTests.java
+++ b/start-site/src/test/java/io/spring/start/site/extension/dependency/graalvm/HibernatePluginGradleBuildCustomizerTests.java
@@ -47,4 +47,25 @@ class HibernatePluginGradleBuildCustomizerTests {
 			.satisfies((plugin) -> assertThat(((StandardGradlePlugin) plugin).getVersion()).isEqualTo("6.1.0.Final"));
 	}
 
+	@Test
+	void customizerAddsJavaPluginBeforeHibernatePlugin() {
+		HibernatePluginGradleBuildCustomizer customizer = new HibernatePluginGradleBuildCustomizer(
+				Version.parse("6.1.0.Final"));
+		GradleBuild build = new GradleBuild();
+		customizer.customize(build);
+		GradlePlugin javaPlugin = build.plugins()
+			.values()
+			.filter((plugin) -> plugin.getId().equals("java"))
+			.findAny()
+			.orElse(null);
+		GradlePlugin hibernatePlugin = build.plugins()
+			.values()
+			.filter((plugin) -> plugin.getId().equals("org.hibernate.orm"))
+			.findAny()
+			.orElse(null);
+		assertThat(javaPlugin).isNotNull();
+		assertThat(hibernatePlugin).isNotNull();
+		assertThat(build.plugins().values()).containsSequence(javaPlugin, hibernatePlugin);
+	}
+
 }


### PR DESCRIPTION
This fixes #1547 by adding the java plugin to the gradle build file (in correct order, java before hibernate)

