### PR TITLE
Upgrade to Spring Cloud GCP 5.5.1

### DIFF
--- a/start-site/src/main/resources/application.yml
+++ b/start-site/src/main/resources/application.yml
@@ -111,8 +111,8 @@ initializr:
         versionProperty: spring-cloud-gcp.version
         additionalBoms: [ spring-cloud ]
         mappings:
-          - compatibilityRange: "[3.2.0,3.3.0-M1)"
-            version: 5.5.0
+          - compatibilityRange: "[3.2.0,3.4.0-M1)"
+            version: 5.5.1
       spring-cloud-services:
         groupId: io.pivotal.spring.cloud
         artifactId: spring-cloud-services-dependencies


### PR DESCRIPTION
Spring cloud GCP [v5.5.1](https://github.com/GoogleCloudPlatform/spring-cloud-gcp/releases/tag/v5.5.1) is released last week. Compatibility with Spring Boot 3.3.x was added in https://github.com/GoogleCloudPlatform/spring-cloud-gcp/pull/2990

This pr should supersede https://github.com/spring-io/start.spring.io/pull/1534.