### PR TITLE
Upgrade Spring AI to 1.0.0-M2

### DIFF
--- a/start-site/src/main/resources/application.yml
+++ b/start-site/src/main/resources/application.yml
@@ -88,7 +88,7 @@ initializr:
         versionProperty: spring-ai.version
         mappings:
           - compatibilityRange: "[3.2.0,3.4.0-M1)"
-            version: 1.0.0-M1
+            version: 1.0.0-M2
             repositories: spring-milestones
       spring-cloud:
         groupId: org.springframework.cloud


### PR DESCRIPTION
Spring AI 1.0.0-M2 was just released late last week. This change simply bumps the version made available at start.spring.io from 1.0.0-M1 to 1.0.0-M2.