### PR TITLE
Generate test app when RabbitMQ Streams is selected

### DIFF
--- a/start-site/src/test/java/io/spring/start/site/extension/dependency/springamqp/SpringAmqpProjectGenerationConfigurationTests.java
+++ b/start-site/src/test/java/io/spring/start/site/extension/dependency/springamqp/SpringAmqpProjectGenerationConfigurationTests.java
@@ -37,6 +37,7 @@ import static org.mockito.Mockito.mock;
  *
  * @author Stephane Nicoll
  * @author Moritz Halbritter
+ * @author Eddú Meléndez
  */
 class SpringAmqpProjectGenerationConfigurationTests extends AbstractExtensionTests {
 
@@ -70,6 +71,19 @@ class SpringAmqpProjectGenerationConfigurationTests extends AbstractExtensionTes
 	@Test
 	void springAmqpWithDockerCompose() {
 		ProjectRequest request = createProjectRequest("docker-compose", "amqp");
+		assertThat(composeFile(request)).hasSameContentAs(new ClassPathResource("compose/rabbitmq.yaml"));
+	}
+
+	@Test
+	void springAmqpStreamsWithoutDockerCompose() {
+		ProjectRequest request = createProjectRequest("web", "amqp-streams");
+		ProjectStructure structure = generateProject(request);
+		assertThat(structure.getProjectDirectory().resolve("compose.yaml")).doesNotExist();
+	}
+
+	@Test
+	void springAmqpStreamsWithDockerCompose() {
+		ProjectRequest request = createProjectRequest("docker-compose", "amqp-streams");
 		assertThat(composeFile(request)).hasSameContentAs(new ClassPathResource("compose/rabbitmq.yaml"));
 	}
 

--- a/start-site/src/test/java/io/spring/start/site/extension/dependency/springamqp/SpringAmqpProjectGenerationConfigurationTests.java
+++ b/start-site/src/test/java/io/spring/start/site/extension/dependency/springamqp/SpringAmqpProjectGenerationConfigurationTests.java
@@ -84,7 +84,7 @@ class SpringAmqpProjectGenerationConfigurationTests extends AbstractExtensionTes
 	@Test
 	void springAmqpStreamsWithDockerCompose() {
 		ProjectRequest request = createProjectRequest("docker-compose", "amqp-streams");
-		assertThat(composeFile(request)).hasSameContentAs(new ClassPathResource("compose/rabbitmq.yaml"));
+		assertThat(composeFile(request)).hasSameContentAs(new ClassPathResource("compose/rabbitmq-streams.yaml"));
 	}
 
 }

--- a/start-site/src/test/resources/compose/rabbitmq-streams.yaml
+++ b/start-site/src/test/resources/compose/rabbitmq-streams.yaml
@@ -1,0 +1,16 @@
+services:
+  rabbitmq:
+    image: 'rabbitmq:latest'
+    environment:
+      - 'RABBITMQ_DEFAULT_PASS=secret'
+      - 'RABBITMQ_DEFAULT_USER=myuser'
+    ports:
+      - '5552'
+      - '5672'
+    configs:
+      - source: "plugins"
+        target: "/etc/rabbitmq/enabled_plugins"
+
+configs:
+  plugins:
+    content: "[rabbitmq_stream]."


### PR DESCRIPTION
Currently, when rabbitmq streams and docker compose/testcontainers are selected, no container is provided. For that reason, the test and test app can not be executed sucessfully. RabbitMQ Streams requires an additional configuration to enable it using Spring Boot and also in the container itself but providing RabbitMQ service would be enough to execute the test and test app.

The configuration to enable rabbitmq streams can be found [here](https://github.com/spring-projects/spring-boot/pull/42443) 
