### PR TITLE
Upgrade Spring AI to 1.0.0-M3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,5 @@ target
 /start-client/package-lock.json
 /start-client/yarn-error.log
 /start-client/analysis
+
+.vscode/

--- a/start-site/src/main/resources/application.yml
+++ b/start-site/src/main/resources/application.yml
@@ -88,7 +88,7 @@ initializr:
         versionProperty: spring-ai.version
         mappings:
           - compatibilityRange: "[3.2.0,3.4.0-M1)"
-            version: 1.0.0-M2
+            version: 1.0.0-M3
             repositories: spring-milestones
       spring-cloud:
         groupId: org.springframework.cloud
@@ -1472,12 +1472,6 @@ initializr:
           id: spring-ai-vectordb-cassandra
           group-id: org.springframework.ai
           artifact-id: spring-ai-cassandra-store-spring-boot-starter
-          # spring-ai-cassandra-store-spring-boot-starter is not managed in the BOM
-          # See https://github.com/spring-projects/spring-ai/pull/1312
-          mappings:
-            - compatibilityRange: "[3.2.0,3.4.0-M1)"
-              version: 1.0.0-M2
-              repository: spring-milestones
           description: Spring AI vector database support for Apache Cassandra.
           starter: true
           links:


### PR DESCRIPTION
 - Upgrade Spring AI version from 1.0.0-M2 to 1.0.0-M3
 - Remove explicit version mapping for spring-ai-cassandra-store-spring-boot-starter
 - Add .vscode/ to .gitignore

 Resolves #1612