### PR TITLE
Update compatibilityRange for Vaadin

### DIFF
--- a/start-site/src/main/resources/application.yml
+++ b/start-site/src/main/resources/application.yml
@@ -148,7 +148,7 @@ initializr:
         artifactId: vaadin-bom
         versionProperty: vaadin.version
         mappings:
-          - compatibilityRange: "[3.3.0,3.4.0-M1)"
+          - compatibilityRange: "[3.3.0,3.5.0-M1)"
             version: 24.5.5
     platform:
       compatibilityRange: "3.3.0"


### PR DESCRIPTION
we have tested Vaadin 24.5 with spring boot 3.4.0, so let us update the compatibilityRange here.