### PR TITLE
Upgrade to MyBatis Spring Boot Starter 3.0.4

### DIFF
--- a/start-site/src/main/resources/application.yml
+++ b/start-site/src/main/resources/application.yml
@@ -513,13 +513,13 @@ initializr:
               description: R2DBC Homepage
         - name: MyBatis Framework
           id: mybatis
-          compatibilityRange: "[3.3.0,3.4.0-M1)"
+          compatibilityRange: "[3.3.0,3.5.0-M1)"
           description: Persistence framework with support for custom SQL, stored procedures and advanced mappings. MyBatis couples objects with stored procedures or SQL statements using a XML descriptor or annotations.
           groupId: org.mybatis.spring.boot
           artifactId: mybatis-spring-boot-starter
           mappings:
-            - compatibilityRange: "[3.3.0,3.4.0-M1)"
-              version: 3.0.3
+            - compatibilityRange: "[3.3.0,3.5.0-M1)"
+              version: 3.0.4
           links:
             - rel: guide
               href: https://github.com/mybatis/spring-boot-starter/wiki/Quick-Start


### PR DESCRIPTION
The MyBatis team release latest version for integrating spring-boot.

* [3.0.4](https://github.com/mybatis/spring-boot-starter/releases/tag/mybatis-spring-boot-3.0.4) for supporting spring-boot 3.4.x and 3.3.x.

FYI:
We perform compatibility check for spring-boot available versions and passed it.
https://github.com/kazuki43zoo/mybatis-spring-boot-dev-compatibility-checker
