### PR TITLE
Generate test app when Spring AI MongoDB Atlas is selected

### DIFF
--- a/start-site/src/main/java/io/spring/start/site/container/SimpleDockerServiceResolver.java
+++ b/start-site/src/main/java/io/spring/start/site/container/SimpleDockerServiceResolver.java
@@ -46,6 +46,7 @@ public class SimpleDockerServiceResolver implements DockerServiceResolver {
 		this.dockerServices.put("mariaDb", mariaDb());
 		this.dockerServices.put("milvus", milvus());
 		this.dockerServices.put("mongoDb", mongoDb());
+		this.dockerServices.put("mongoDbAtlas", mongoDbAtlas());
 		this.dockerServices.put("mysql", mysql());
 		this.dockerServices.put("neo4j", neo4j());
 		this.dockerServices.put("ollama", ollama());
@@ -139,6 +140,13 @@ public class SimpleDockerServiceResolver implements DockerServiceResolver {
 
 	private static DockerService mongoDb() {
 		return DockerService.withImageAndTag("mongo").website("https://hub.docker.com/_/mongo").ports(27017).build();
+	}
+
+	private static DockerService mongoDbAtlas() {
+		return DockerService.withImageAndTag("mongodb/mongodb-atlas-local")
+			.website("https://hub.docker.com/r/mongodb/mongodb-atlas-local")
+			.ports(27017)
+			.build();
 	}
 
 	private static DockerService mysql() {

--- a/start-site/src/main/java/io/spring/start/site/extension/dependency/springai/SpringAiMongoDbAtlasProjectGenerationConfiguration.java
+++ b/start-site/src/main/java/io/spring/start/site/extension/dependency/springai/SpringAiMongoDbAtlasProjectGenerationConfiguration.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2012-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.spring.start.site.extension.dependency.springai;
+
+import io.spring.initializr.generator.condition.ConditionalOnPlatformVersion;
+import io.spring.initializr.generator.condition.ConditionalOnRequestedDependency;
+import io.spring.initializr.generator.project.ProjectGenerationConfiguration;
+import io.spring.start.site.container.ComposeFileCustomizer;
+import io.spring.start.site.container.DockerServiceResolver;
+import io.spring.start.site.container.ServiceConnections.ServiceConnection;
+import io.spring.start.site.container.ServiceConnectionsCustomizer;
+
+import org.springframework.context.annotation.Bean;
+
+/**
+ * Configuration for generation of projects that depend on MongoDb Atlas.
+ *
+ * @author Eddú Meléndez
+ */
+@ProjectGenerationConfiguration
+@ConditionalOnPlatformVersion("3.4.0")
+@ConditionalOnRequestedDependency("spring-ai-vectordb-mongodb-atlas")
+class SpringAiMongoDbAtlasProjectGenerationConfiguration {
+
+	private static final String TESTCONTAINERS_CLASS_NAME = "org.testcontainers.mongodb.MongoDBAtlasLocalContainer";
+
+	@Bean
+	@ConditionalOnRequestedDependency("testcontainers")
+	ServiceConnectionsCustomizer mongodbAtlasServiceConnectionsCustomizer(DockerServiceResolver serviceResolver) {
+		return (serviceConnections) -> serviceResolver.doWith("mongoDbAtlas",
+				(service) -> serviceConnections.addServiceConnection(
+						ServiceConnection.ofContainer("mongoDbAtlas", service, TESTCONTAINERS_CLASS_NAME, false)));
+	}
+
+	@Bean
+	@ConditionalOnRequestedDependency("docker-compose")
+	ComposeFileCustomizer mongodbAtlasComposeFileCustomizer(DockerServiceResolver serviceResolver) {
+		return (composeFile) -> serviceResolver.doWith("mongoDbAtlas",
+				(service) -> composeFile.services().add("mongodbatlas", service));
+	}
+
+}

--- a/start-site/src/main/java/io/spring/start/site/extension/dependency/testcontainers/TestcontainersModuleRegistry.java
+++ b/start-site/src/main/java/io/spring/start/site/extension/dependency/testcontainers/TestcontainersModuleRegistry.java
@@ -59,7 +59,8 @@ abstract class TestcontainersModuleRegistry {
 		builders.add(onDependencies("data-elasticsearch", "spring-ai-vectordb-elasticsearch")
 			.customizeBuild(addModule("elasticsearch"))
 			.customizeHelpDocument(addReferenceLink("Elasticsearch Container", "elasticsearch/")));
-		builders.add(onDependencies("data-mongodb", "data-mongodb-reactive").customizeBuild(addModule("mongodb"))
+		builders.add(onDependencies("data-mongodb", "data-mongodb-reactive", "spring-ai-vectordb-mongodb-atlas")
+			.customizeBuild(addModule("mongodb"))
 			.customizeHelpDocument(addReferenceLink("MongoDB Module", "databases/mongodb/")));
 		builders.add(onDependencies("data-neo4j", "spring-ai-vectordb-neo4j").customizeBuild(addModule("neo4j"))
 			.customizeHelpDocument(addReferenceLink("Neo4j Module", "databases/neo4j/")));

--- a/start-site/src/main/resources/META-INF/spring.factories
+++ b/start-site/src/main/resources/META-INF/spring.factories
@@ -31,6 +31,7 @@ io.spring.start.site.extension.dependency.solace.SolaceProjectGenerationConfigur
 io.spring.start.site.extension.dependency.springai.SpringAiChromaProjectGenerationConfiguration,\
 io.spring.start.site.extension.dependency.springai.SpringAiDockerComposeProjectGenerationConfiguration,\
 io.spring.start.site.extension.dependency.springai.SpringAiMilvusProjectGenerationConfiguration,\
+io.spring.start.site.extension.dependency.springai.SpringAiMongoDbAtlasProjectGenerationConfiguration,\
 io.spring.start.site.extension.dependency.springai.SpringAiOllamaProjectGenerationConfiguration,\
 io.spring.start.site.extension.dependency.springai.SpringAiQdrantProjectGenerationConfiguration,\
 io.spring.start.site.extension.dependency.springai.SpringAiTestcontainersProjectGenerationConfiguration,\

--- a/start-site/src/test/java/io/spring/start/site/extension/dependency/springai/SpringAiMongoDbAtlasProjectGenerationConfigurationTests.java
+++ b/start-site/src/test/java/io/spring/start/site/extension/dependency/springai/SpringAiMongoDbAtlasProjectGenerationConfigurationTests.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2012-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.spring.start.site.extension.dependency.springai;
+
+import io.spring.initializr.generator.test.project.ProjectStructure;
+import io.spring.initializr.web.project.ProjectRequest;
+import io.spring.start.site.extension.AbstractExtensionTests;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.core.io.ClassPathResource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link SpringAiMongoDbAtlasProjectGenerationConfiguration}
+ *
+ * @author Eddú Meléndez
+ */
+class SpringAiMongoDbAtlasProjectGenerationConfigurationTests extends AbstractExtensionTests {
+
+	@Test
+	void doesNothingWithoutDockerCompose() {
+		ProjectRequest request = createProjectRequest("web", "spring-ai-vectordb-mongodb-atlas");
+		ProjectStructure structure = generateProject(request);
+		assertThat(structure.getProjectDirectory().resolve("compose.yaml")).doesNotExist();
+	}
+
+	@Test
+	void createsMongoDbAtlasService() {
+		ProjectRequest request = createProjectRequest("docker-compose", "spring-ai-vectordb-mongodb-atlas");
+		assertThat(composeFile(request)).hasSameContentAs(new ClassPathResource("compose/mongodb-atlas.yaml"));
+	}
+
+}

--- a/start-site/src/test/java/io/spring/start/site/extension/dependency/testcontainers/TestcontainersProjectGenerationConfigurationTests.java
+++ b/start-site/src/test/java/io/spring/start/site/extension/dependency/testcontainers/TestcontainersProjectGenerationConfigurationTests.java
@@ -79,6 +79,7 @@ class TestcontainersProjectGenerationConfigurationTests extends AbstractExtensio
 	static Stream<Arguments> supportedTestcontainersSpringAiEntriesBuild() {
 		return Stream.of(Arguments.arguments("spring-ai-vectordb-chroma", "chromadb"),
 				Arguments.arguments("spring-ai-vectordb-milvus", "milvus"),
+				Arguments.arguments("spring-ai-vectordb-mongodb-atlas", "mongodb"),
 				Arguments.arguments("spring-ai-vectordb-qdrant", "qdrant"),
 				Arguments.arguments("spring-ai-vectordb-weaviate", "weaviate"));
 	}

--- a/start-site/src/test/resources/compose/mongodb-atlas.yaml
+++ b/start-site/src/test/resources/compose/mongodb-atlas.yaml
@@ -1,0 +1,5 @@
+services:
+  mongodbatlas:
+    image: 'mongodb/mongodb-atlas-local:latest'
+    ports:
+      - '27017'


### PR DESCRIPTION
Testcontainers 1.20.2 provides `MongoDBAtlasLocalContainer` and
Spring AI 1.0.0-M3 supports it.

Spring Boot 3.4.0 already provides Testcontainers 1.20.4.
