### PR TITLE
Add help section and Maven plugin when azure-support is selected

### DIFF
--- a/start-site/src/main/java/io/spring/start/site/extension/dependency/springazure/SpringAzureMavenBuildCustomizer.java
+++ b/start-site/src/main/java/io/spring/start/site/extension/dependency/springazure/SpringAzureMavenBuildCustomizer.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2012-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.spring.start.site.extension.dependency.springazure;
+
+import io.spring.initializr.generator.buildsystem.maven.MavenBuild;
+import io.spring.initializr.generator.project.ProjectDescription;
+import io.spring.initializr.generator.spring.build.BuildCustomizer;
+
+/**
+ * A {@link BuildCustomizer} that adds a maven plugin when azure-support is selected.
+ *
+ * @author Muyao Feng
+ */
+class SpringAzureMavenBuildCustomizer implements BuildCustomizer<MavenBuild> {
+
+	private final ProjectDescription projectDescription;
+
+	SpringAzureMavenBuildCustomizer(ProjectDescription projectDescription) {
+		this.projectDescription = projectDescription;
+	}
+
+	@Override
+	public void customize(MavenBuild build) {
+		build.plugins().add("com.microsoft.azure", "azure-container-apps-maven-plugin", (plugin) -> {
+			plugin.version("0.1.0");
+			plugin.configuration((configuration) -> {
+				configuration.add("subscriptionId", "your-subscription-id");
+				configuration.add("resourceGroup", "your-resource-group");
+				configuration.add("appEnvironmentName", "your-app-environment-name");
+				configuration.add("region", "your-region");
+				configuration.add("appName", this.projectDescription.getName());
+				configuration.add("containers", (containers) -> {
+					containers.add("container", (container) -> {
+						container.add("type", "code");
+						container.add("directory", "${project.basedir}");
+					});
+				});
+				configuration.add("ingress", (ingress) -> {
+					ingress.add("external", "true");
+					ingress.add("targetPort", "8080");
+				});
+				configuration.add("scale", (scale) -> {
+					scale.add("minReplicas", "0");
+					scale.add("maxReplicas", "10");
+				});
+			});
+		});
+	}
+
+}

--- a/start-site/src/main/java/io/spring/start/site/extension/dependency/springazure/SpringAzureModuleRegistry.java
+++ b/start-site/src/main/java/io/spring/start/site/extension/dependency/springazure/SpringAzureModuleRegistry.java
@@ -37,7 +37,7 @@ import io.spring.start.site.support.implicit.ImplicitDependency.Builder;
 abstract class SpringAzureModuleRegistry {
 
 	static Iterable<ImplicitDependency> createSpringBootRegistry() {
-		return create(
+		return create(onDependencies("azure-support").customizeHelpDocument(addDeploySection()),
 				onDependencies("actuator").customizeBuild(addDependency("spring-cloud-azure-starter-actuator"))
 					.customizeHelpDocument(addReferenceLink("actuator", "Azure Actuator")),
 				onDependencies("integration", "azure-storage")
@@ -78,6 +78,32 @@ abstract class SpringAzureModuleRegistry {
 		return (helpDocument) -> {
 			String href = String.format("https://aka.ms/spring/docs/%s", id);
 			helpDocument.gettingStarted().addReferenceDocLink(href, description);
+		};
+	}
+
+	private static Consumer<HelpDocument> addDeploySection() {
+		return (helpDocument) -> {
+			helpDocument.addSection((writer) -> {
+				writer.println("### Deploy to Azure");
+				writer.println();
+				writer.println("This project can be deployed to Azure with maven support.");
+				writer.println();
+				writer.println(
+						"In your `pom.xml`, replace the following placeholder variables with your specific Azure details:");
+				writer.println("- `subscriptionId`");
+				writer.println("- `resourceGroup`");
+				writer.println("- `appEnvironmentName`");
+				writer.println("- `region`");
+				writer.println();
+				writer.println("Deploy with:");
+				writer.println("""
+						```bash
+						mvn azure-container-apps:deploy
+						```
+						""");
+				writer.println(
+						"Learn more about [Java on Azure Container Apps](https://learn.microsoft.com/azure/container-apps/java-overview).");
+			});
 		};
 	}
 

--- a/start-site/src/main/java/io/spring/start/site/extension/dependency/springazure/SpringAzureProjectGenerationConfiguration.java
+++ b/start-site/src/main/java/io/spring/start/site/extension/dependency/springazure/SpringAzureProjectGenerationConfiguration.java
@@ -17,6 +17,8 @@
 package io.spring.start.site.extension.dependency.springazure;
 
 import io.spring.initializr.generator.buildsystem.Build;
+import io.spring.initializr.generator.condition.ConditionalOnRequestedDependency;
+import io.spring.initializr.generator.project.ProjectDescription;
 import io.spring.initializr.generator.project.ProjectGenerationConfiguration;
 import io.spring.start.site.support.implicit.ImplicitDependency;
 import io.spring.start.site.support.implicit.ImplicitDependencyBuildCustomizer;
@@ -48,6 +50,12 @@ class SpringAzureProjectGenerationConfiguration {
 	@Bean
 	ImplicitDependencyHelpDocumentCustomizer azureDependencyHelpDocumentCustomizer(Build build) {
 		return new ImplicitDependencyHelpDocumentCustomizer(this.azureDependencies, build);
+	}
+
+	@Bean
+	@ConditionalOnRequestedDependency("azure-support")
+	SpringAzureMavenBuildCustomizer azureDependencyMavenBuildCustomizer(ProjectDescription projectDescription) {
+		return new SpringAzureMavenBuildCustomizer(projectDescription);
 	}
 
 }

--- a/start-site/src/test/java/io/spring/start/site/extension/dependency/springazure/SpringAzureMavenBuildCustomizerTests.java
+++ b/start-site/src/test/java/io/spring/start/site/extension/dependency/springazure/SpringAzureMavenBuildCustomizerTests.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2012-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.spring.start.site.extension.dependency.springazure;
+
+import io.spring.initializr.web.project.ProjectRequest;
+import io.spring.start.site.extension.AbstractExtensionTests;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link SpringAzureMavenBuildCustomizer}.
+ *
+ * @author Muyao Feng
+ */
+class SpringAzureMavenBuildCustomizerTests extends AbstractExtensionTests {
+
+	@Test
+	void azureContainerAppsMavenPluginAddedWhenAzureSupportPresent() {
+		ProjectRequest request = createProjectRequest("azure-support");
+		assertThat(mavenPom(request)).hasText("/project/build/plugins/plugin[1]/groupId", "com.microsoft.azure");
+		assertThat(mavenPom(request)).hasText("/project/build/plugins/plugin[1]/artifactId",
+				"azure-container-apps-maven-plugin");
+	}
+
+}

--- a/start-site/src/test/java/io/spring/start/site/extension/dependency/springazure/SpringAzureProjectGenerationConfigurationTests.java
+++ b/start-site/src/test/java/io/spring/start/site/extension/dependency/springazure/SpringAzureProjectGenerationConfigurationTests.java
@@ -118,6 +118,12 @@ class SpringAzureProjectGenerationConfigurationTests extends AbstractExtensionTe
 			.doesNotContain("https://aka.ms/spring/msdocs/mysql");
 	}
 
+	@Test
+	void DeploytoAzureSectionAddedWhenAzureSupportPresent() {
+		ProjectStructure project = generateProject("azure-support");
+		assertThatHelpDocumentOf(project).contains("Deploy to Azure");
+	}
+
 	private static Stream<Arguments> azureDependencies() {
 		return Stream.of(Arguments.of("azure-active-directory"), Arguments.of("azure-keyvault"),
 				Arguments.of("azure-storage"), Arguments.of("azure-support"));


### PR DESCRIPTION
When select azure-support:
 - Add `Deploy to Azure` section in Help.md
 - Add `azure-container-apps-maven-plugin` in pom