### PR TITLE
Allow removal of dependencies from the dependencies selection UI

### DIFF
--- a/start-client/src/components/common/dependency/Dialog.js
+++ b/start-client/src/components/common/dependency/Dialog.js
@@ -256,6 +256,9 @@ function Dialog({ onClose }) {
                       }}
                       onRemoved={(item) => {
                         setSelectedDeps(selectedDeps.filter(id => id !== item.id))
+                        if (item.valid && !multiple) {
+                          onClose()
+                        }
                       }}
                       onSelect={() => {
                         setSelected(index)
@@ -286,6 +289,9 @@ function Dialog({ onClose }) {
                             }}
                             onRemoved={(item) => {
                               setSelectedDeps(selectedDeps.filter(id => id !== item.id))
+                              if (item.valid && !multiple) {
+                                onClose()
+                              }
                             }}
                             onSelect={i => {
                               setSelected(i)

--- a/start-client/src/components/common/dependency/Dialog.js
+++ b/start-client/src/components/common/dependency/Dialog.js
@@ -48,6 +48,13 @@ function Dialog({ onClose }) {
     })
   }
 
+  const remove = id => {
+    dispatch({
+      type: 'REMOVE_DEPENDENCY',
+      payload: { id: id },
+    })
+  }
+
   useEffect(() => {
     const jsSearchUp = new JsSearch.Search('name')
     jsSearchUp.addIndex('name')
@@ -157,7 +164,11 @@ function Dialog({ onClose }) {
       case 13: // Enter
         event.preventDefault()
         if (selected < result.length && result[selected].valid) {
-          add(result[selected].id)
+          if (!selectedDeps.find(id => id === result[selected].id)) {
+            add(result[selected].id)
+          } else {
+            remove(result[selected].id)
+          }
         }
         if (!multiple) {
           onClose()

--- a/start-client/src/components/common/dependency/Dialog.js
+++ b/start-client/src/components/common/dependency/Dialog.js
@@ -31,6 +31,7 @@ function Dialog({ onClose }) {
   const wrapper = useRef(null)
   const input = useRef(null)
   const dialog = useRef(null)
+  const selectedDependencies = useRef(null)
 
   const { values, dispatch } = useContext(InitializrContext)
   const [query, setQuery] = useState('')
@@ -45,6 +46,14 @@ function Dialog({ onClose }) {
       type: 'ADD_DEPENDENCY',
       payload: { id },
     })
+  }
+
+  const remove = (id) => {
+    dispatch({
+      type: 'REMOVE_DEPENDENCY',
+      payload: { id },
+    })
+    textFocus()
   }
 
   useEffect(() => {
@@ -100,10 +109,12 @@ function Dialog({ onClose }) {
   useEffect(() => {
     const clickOutside = event => {
       const children = get(wrapper, 'current')
+      const selectedDeps = get(selectedDependencies, 'current')
       if (
-        children &&
-        !children.contains(event.target) &&
-        event.target.id !== 'input-quicksearch'
+        (children &&
+          !children.contains(event.target) &&
+          event.target.id !== 'input-quicksearch') &&
+        (!selectedDeps || (selectedDeps && !selectedDeps.contains(event.target)))
       ) {
         onClose()
       }
@@ -202,7 +213,7 @@ function Dialog({ onClose }) {
 
   const onEnded = () => {
     setMultiple(false)
-    setTimeout(() => {}, 300)
+    setTimeout(() => { }, 300)
   }
 
   let currentIndex = -1
@@ -248,53 +259,79 @@ function Dialog({ onClose }) {
                   Press {windowsUtils.symb} for multiple adds{' '}
                 </span>
               </div>
-              <ul ref={wrapper}>
+              {values.dependencies.length > 0 &&
+                <div
+                  id='selected-dependencies'
+                  className='selected-dependencies'
+                  ref={selectedDependencies}
+                >
+                  <span>Selected</span>
+                  {values.dependencies.map(dep => (
+                    <div className="selected">
+                      <span>{
+                        depsContext.list
+                          .filter(item => item.id === dep)
+                          .map(item => item.name)
+                          .at(0)
+                      }
+                      </span>
+                      <span
+                        className='dialog-remove-dependency'
+                        onClick={() => remove(dep)}
+                      >
+                        <IconTimes />
+                      </span>
+                    </div>
+                  ))}
+                </div>
+              }
+              <ul ref={wrapper} style={{ top: values.dependencies.length > 0 ? '100px' : '50px' }}>
                 {query.trim()
                   ? result.map((item, index) => (
-                      <Item
-                        selected={selected === index}
-                        item={item}
-                        index={index}
-                        key={item.id}
-                        onAdd={() => {
-                          textFocus()
-                          if (item.valid && !multiple) {
-                            onClose()
-                          }
-                        }}
-                        onSelect={() => {
-                          setSelected(index)
-                        }}
-                      />
-                    ))
+                    <Item
+                      selected={selected === index}
+                      item={item}
+                      index={index}
+                      key={item.id}
+                      onAdd={() => {
+                        textFocus()
+                        if (item.valid && !multiple) {
+                          onClose()
+                        }
+                      }}
+                      onSelect={() => {
+                        setSelected(index)
+                      }}
+                    />
+                  ))
                   : groups.map(group => (
-                      <>
-                        <li key={group.group} className='group-title'>
-                          <span>{group.group}</span>
-                        </li>
-                        {group.items.map(itemGroup => {
-                          currentIndex = +`${currentIndex + 1}`
-                          return (
-                            <Item
-                              selected={selected === currentIndex}
-                              item={itemGroup}
-                              key={itemGroup.id}
-                              index={currentIndex}
-                              group={false}
-                              onAdd={() => {
-                                textFocus()
-                                if (itemGroup.valid && !multiple) {
-                                  onClose()
-                                }
-                              }}
-                              onSelect={i => {
-                                setSelected(i)
-                              }}
-                            />
-                          )
-                        })}
-                      </>
-                    ))}
+                    <>
+                      <li key={group.group} className='group-title'>
+                        <span>{group.group}</span>
+                      </li>
+                      {group.items.map(itemGroup => {
+                        currentIndex = +`${currentIndex + 1}`
+                        return (
+                          <Item
+                            selected={selected === currentIndex}
+                            item={itemGroup}
+                            key={itemGroup.id}
+                            index={currentIndex}
+                            group={false}
+                            onAdd={() => {
+                              textFocus()
+                              if (itemGroup.valid && !multiple) {
+                                onClose()
+                              }
+                            }}
+                            onSelect={i => {
+                              setSelected(i)
+                            }}
+                          />
+                        )
+                      })}
+                    </>
+                  ))}
               </ul>
             </div>
           </CSSTransition>

--- a/start-client/src/components/common/dependency/Dialog.js
+++ b/start-client/src/components/common/dependency/Dialog.js
@@ -79,9 +79,6 @@ function Dialog({ onClose }) {
       if (query.trim()) {
         vals = sortResult(search.search(query))
       }
-      vals = vals.filter(
-        item => !get(values, 'dependencies', []).find(o => o === item.id)
-      )
       setResult(vals)
     }
     onSearch()

--- a/start-client/src/components/common/dependency/Item.js
+++ b/start-client/src/components/common/dependency/Item.js
@@ -5,26 +5,31 @@ import React, { useContext } from 'react'
 import { IconEnter } from '../icons'
 import { InitializrContext } from '../../reducer/Initializr'
 
-function Item({ item, selected, onSelect, onAdd, group, index }) {
+function Item({ item, selected, onSelect, onAdd, onRemoved, group, index, added }) {
   const { dispatch } = useContext(InitializrContext)
 
   const onClick = event => {
     event.preventDefault()
-    if (item.valid) {
+    if (item.valid && !added) {
       dispatch({
         type: 'ADD_DEPENDENCY',
         payload: { id: item.id },
       })
+      onAdd(item)
+    } else if (item.valid && added) {
+      dispatch({
+        type: 'REMOVE_DEPENDENCY',
+        payload: { id: item.id },
+      })
+      onRemoved(item)
     }
-    onAdd()
   }
   return (
     <li key={`li-${get(item, 'id')}`}>
       <a
         href='/'
-        className={`dependency ${selected ? 'selected' : ''} ${
-          !item.valid ? 'disabled' : ''
-        }`}
+        className={`dependency ${selected ? 'selected' : ''} ${added ? 'added' : ''} ${!item.valid ? 'disabled' : ''
+          }`}
         onClick={onClick}
         onMouseMove={() => {
           onSelect(index)

--- a/start-client/src/styles/_dark.scss
+++ b/start-client/src/styles/_dark.scss
@@ -182,6 +182,23 @@ body.dark {
   ul.dependencies-list li div span.group {
     color: $dark-background;
   }
+  .dialog-dependencies div.selected {
+    display: inline-flex;
+    gap: 4px;
+    background-color: $dark-primary;
+    border-radius: 4px;
+    margin: 0px 4px;
+    padding: 2px 4px;
+    z-index: 100; 
+
+    .dialog-remove-dependency {
+      cursor: pointer;
+      svg {
+        height: 10px;
+        width: 10px;
+      }
+    }
+  }
   ul.dependencies-list li {
     border-color: $dark-border;
   }

--- a/start-client/src/styles/_dark.scss
+++ b/start-client/src/styles/_dark.scss
@@ -182,23 +182,6 @@ body.dark {
   ul.dependencies-list li div span.group {
     color: $dark-background;
   }
-  .dialog-dependencies div.selected {
-    display: inline-flex;
-    gap: 4px;
-    background-color: $dark-primary;
-    border-radius: 4px;
-    margin: 0px 4px;
-    padding: 2px 4px;
-    z-index: 100; 
-
-    .dialog-remove-dependency {
-      cursor: pointer;
-      svg {
-        height: 10px;
-        width: 10px;
-      }
-    }
-  }
   ul.dependencies-list li {
     border-color: $dark-border;
   }
@@ -405,6 +388,9 @@ body.dark {
   }
   #header .switch-mobile button {
     color: $dark-color;
+  }
+  .dialog-dependencies ul li a.dependency.added {
+    background: darken($dark-primary, 10);
   }
   .dialog-dependencies ul li.group-title span,
   .dialog-dependencies ul li a.dependency.selected,

--- a/start-client/src/styles/_main.scss
+++ b/start-client/src/styles/_main.scss
@@ -892,27 +892,6 @@ button.button {
     padding: 1.5rem 0 0.5rem;
     font-size: 24px;
   }
-  .selected-dependencies {
-    display: flex;
-    align-items: center;
-    padding: 5px;
-    margin: 0;
-    position: absolute;
-    left: 0;
-    right: 0;
-    top: 50px;
-    height: 50px; 
-    overflow-x: auto;
-    white-space: nowrap;
-    &::-webkit-scrollbar {
-      height: 6px;
-      width: 6px;
-      background: $light-background;
-    }
-    &::-webkit-scrollbar-thumb {
-      background: rgba(black, 0.3);
-    }
-  }
   ul {
     padding: 0;
     margin: 0;
@@ -973,6 +952,27 @@ button.button {
           margin-top: -(calc($height / 2));
           height: $height;
           right: 15px;
+        }
+        &.added {
+          color: white;
+          background: darken($light-primary, 10);
+          margin-bottom: -1px;
+          margin-top: -1px;
+          padding: 13px 1rem;
+          padding-right: 45px;
+          box-shadow: inset 0 1px 0 rgba(white, 0.2);
+          &:hover {
+            strong {
+              color: white;
+            }
+          }
+          span.group {
+            background: white;
+            color: $light-color;
+          }
+          .icon-enter {
+            display: block;
+          }
         }
         &.selected {
           color: white;

--- a/start-client/src/styles/_main.scss
+++ b/start-client/src/styles/_main.scss
@@ -892,6 +892,27 @@ button.button {
     padding: 1.5rem 0 0.5rem;
     font-size: 24px;
   }
+  .selected-dependencies {
+    display: flex;
+    align-items: center;
+    padding: 5px;
+    margin: 0;
+    position: absolute;
+    left: 0;
+    right: 0;
+    top: 50px;
+    height: 50px; 
+    overflow-x: auto;
+    white-space: nowrap;
+    &::-webkit-scrollbar {
+      height: 6px;
+      width: 6px;
+      background: $light-background;
+    }
+    &::-webkit-scrollbar-thumb {
+      background: rgba(black, 0.3);
+    }
+  }
   ul {
     padding: 0;
     margin: 0;


### PR DESCRIPTION
Users might misclic or change their mind about adding a dependency. Having to close the dialog in order to remove the dependency is unnecessary extra work.

This makes it so that the selected dependencies list is shown inside the dialog in a non-obstrusive way so that users can see what they've chosen so far and potentially remove them.

<!--
Thanks for contributing to start.spring.io Please review the following notes before
submitting you pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Proposal for New Entries

STOP! If your contribution suggests the addition of a new entry, please do not submit it
Rather create a "New Entry Proposal" issue as we need some information from you before
proceeding.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->



https://github.com/user-attachments/assets/a3b5955b-c350-432b-8b7b-4147cd0986d2

