### PR TITLE
Update Spring Modulith versions

### DIFF
--- a/start-site/src/main/resources/application.yml
+++ b/start-site/src/main/resources/application.yml
@@ -137,9 +137,11 @@ initializr:
         versionProperty: spring-modulith.version
         mappings:
           - compatibilityRange: "[3.3.0,3.4.0-M1)"
-            version: 1.2.8
+            version: 1.2.9
           - compatibilityRange: "[3.4.0,3.5.0-M1)"
-            version: 1.3.2
+            version: 1.3.3
+          - compatibilityRange: "[3.5.0-M1,3.6.0-M1)"
+            version: 1.4.0-M2
       spring-shell:
         groupId: org.springframework.shell
         artifactId: spring-shell-dependencies
@@ -221,7 +223,7 @@ initializr:
         - name: Spring Modulith
           id: modulith
           bom: spring-modulith
-          compatibilityRange: "[3.3.0,3.5.0-M1)"
+          compatibilityRange: "[3.3.0,3.6.0-M1)"
           group-id: org.springframework.modulith
           artifact-id: spring-modulith-starter-core
           description: Support for building modular monolithic applications.


### PR DESCRIPTION
Also added version mappings for the Boot 3.5 generation. Arbitrarily chose 3.6.0-M1 as forward delimiter. Please adapt if that was the wrong choice.
