### PR TITLE
Disable dates in @Generated annotations for DGS Codegen Maven

### DIFF
--- a/start-site/src/main/java/io/spring/start/site/extension/dependency/dgs/DgsCodegenMavenBuildCustomizer.java
+++ b/start-site/src/main/java/io/spring/start/site/extension/dependency/dgs/DgsCodegenMavenBuildCustomizer.java
@@ -49,7 +49,8 @@ public class DgsCodegenMavenBuildCustomizer implements BuildCustomizer<MavenBuil
 												(schemaPaths) -> schemaPaths.add("param",
 														"src/main/resources/graphql-client"))
 										.add("packageName", this.packageName + ".codegen")
-										.add("addGeneratedAnnotation", "true"))));
+										.add("addGeneratedAnnotation", "true")
+										.add("disableDatesInGeneratedAnnotation", "true"))));
 		build.plugins()
 			.add("org.codehaus.mojo", "build-helper-maven-plugin",
 					(plugin) -> plugin.execution("add-dgs-source", (execution) -> execution.goal("add-source")

--- a/start-site/src/test/java/io/spring/start/site/extension/dependency/dgs/DgsCodegenProjectGenerationConfigurationTests.java
+++ b/start-site/src/test/java/io/spring/start/site/extension/dependency/dgs/DgsCodegenProjectGenerationConfigurationTests.java
@@ -102,6 +102,7 @@ class DgsCodegenProjectGenerationConfigurationTests extends AbstractExtensionTes
 				"							</schemaPaths>",
 				"							<packageName>com.example.demo.codegen</packageName>",
 				"							<addGeneratedAnnotation>true</addGeneratedAnnotation>",
+				"							<disableDatesInGeneratedAnnotation>true</disableDatesInGeneratedAnnotation>",
 				"						</configuration>",
 				"					</execution>",
 				"				</executions>",


### PR DESCRIPTION
This is a reimplementation of https://github.com/spring-io/start.spring.io/pull/1533 now that the plugin offers the `disableDatesInGeneratedAnnotation` configuration option. These dates prevent byte-for-byte reproducibility of the generated sources.

