### PR TITLE
Upgrade netflix-dgs to 10.2.1 for Spring Boot 3.5

### DIFF
--- a/start-site/src/main/resources/application.yml
+++ b/start-site/src/main/resources/application.yml
@@ -59,6 +59,8 @@ initializr:
         mappings:
           - compatibilityRange: "[3.3.0,3.5.0-M1)"
             version: 10.1.2
+          - compatibilityRange: "[3.5.0,3.6.0-M1)"
+            version: 10.2.1
       sentry:
         groupId: io.sentry
         artifactId: sentry-bom
@@ -360,7 +362,7 @@ initializr:
           groupId: com.netflix.graphql.dgs
           artifactId: graphql-dgs-spring-graphql-starter
           description: Build GraphQL applications with Netflix DGS and Spring for GraphQL.
-          compatibilityRange: "[3.3.0,3.5.0-M1)"
+          compatibilityRange: "[3.3.0,3.6.0-M1)"
           bom: netflix-dgs
           links:
             - rel: reference

--- a/start-site/src/test/java/io/spring/start/site/extension/dependency/dgs/DgsBuildCustomizerTests.java
+++ b/start-site/src/test/java/io/spring/start/site/extension/dependency/dgs/DgsBuildCustomizerTests.java
@@ -18,7 +18,6 @@ package io.spring.start.site.extension.dependency.dgs;
 
 import io.spring.initializr.metadata.Dependency;
 import io.spring.initializr.web.project.ProjectRequest;
-import io.spring.start.site.SupportedBootVersion;
 import io.spring.start.site.extension.AbstractExtensionTests;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -26,8 +25,6 @@ import org.junit.jupiter.api.Test;
 import static org.assertj.core.api.Assertions.assertThat;
 
 class DgsBuildCustomizerTests extends AbstractExtensionTests {
-
-	private static final SupportedBootVersion BOOT_VERSION = SupportedBootVersion.V3_4;
 
 	private Dependency dgsTest;
 
@@ -40,7 +37,7 @@ class DgsBuildCustomizerTests extends AbstractExtensionTests {
 
 	@Test
 	void shouldAddTestingDependency() {
-		ProjectRequest request = createProjectRequest(BOOT_VERSION, "web", "netflix-dgs");
+		ProjectRequest request = createProjectRequest("web", "netflix-dgs");
 		assertThat(mavenPom(request)).hasDependency(Dependency.createSpringBootStarter("web"))
 			.hasDependency(Dependency.createSpringBootStarter("test", Dependency.SCOPE_TEST))
 			.hasDependency(this.dgsTest)


### PR DESCRIPTION
Add new version of netflix-dgs 10.2.1 that includes compatibility with Spring Boot 3.5 Release series.

This change keeps older versions for previous Spring Boot Releases.