### PR TITLE
Upgrade to Vaadin 24.8.0

### DIFF
--- a/start-site/src/main/resources/application.yml
+++ b/start-site/src/main/resources/application.yml
@@ -172,8 +172,10 @@ initializr:
         artifactId: vaadin-bom
         versionProperty: vaadin.version
         mappings:
-          - compatibilityRange: "[3.4.0,3.6.0-M1)"
+          - compatibilityRange: "[3.4.0,3.5.0-M1)"
             version: 24.7.6
+          - compatibilityRange: "[3.5.0,3.6.0-M1)"
+            version: 24.8.0
     platform:
       compatibilityRange: "3.3.0"
   dependencies:


### PR DESCRIPTION
as Vaadin 24.8 doesn't support SpringBoot 3.4 any more. 
so i split the compatibilityRange into [3.4.0, 3.5.0-M1) and [3.5.0, 3.6.0-M1)