### PR TITLE
Drop old 'jakarta_omit' option

### DIFF
--- a/start-site/src/main/java/io/spring/start/site/extension/dependency/springgrpc/GrpcGradleGroovyBuildCustomizer.java
+++ b/start-site/src/main/java/io/spring/start/site/extension/dependency/springgrpc/GrpcGradleGroovyBuildCustomizer.java
@@ -39,7 +39,6 @@ class GrpcGradleGroovyBuildCustomizer extends AbstractGrpcGradleBuildCustomizer 
 					(grpc) -> grpc.attribute("artifact", quote("io.grpc:protoc-gen-grpc-java"))));
 			protobuf.nested("generateProtoTasks", (generateProtoTasks) -> generateProtoTasks.nested("all()*.plugins",
 					(plugins) -> plugins.nested("grpc", (grpc) -> {
-						grpc.invoke("option", quote("jakarta_omit"));
 						grpc.invoke("option", quote("@generated=omit"));
 					})));
 		});

--- a/start-site/src/main/java/io/spring/start/site/extension/dependency/springgrpc/GrpcGradleKotlinBuildCustomizer.java
+++ b/start-site/src/main/java/io/spring/start/site/extension/dependency/springgrpc/GrpcGradleKotlinBuildCustomizer.java
@@ -40,7 +40,6 @@ class GrpcGradleKotlinBuildCustomizer extends AbstractGrpcGradleBuildCustomizer 
 					(grpc) -> grpc.attribute("artifact", quote("io.grpc:protoc-gen-grpc-java"))));
 			protobuf.nested("generateProtoTasks", (generateProtoTasks) -> generateProtoTasks.nested("all().forEach",
 					(forEach) -> forEach.nested("it.plugins", (plugins) -> plugins.nested("id(\"grpc\")", (grpc) -> {
-						grpc.invoke("option", quote("jakarta_omit"));
 						grpc.invoke("option", quote("@generated=omit"));
 					}))));
 		});

--- a/start-site/src/main/java/io/spring/start/site/extension/dependency/springgrpc/GrpcMavenBuildCustomizer.java
+++ b/start-site/src/main/java/io/spring/start/site/extension/dependency/springgrpc/GrpcMavenBuildCustomizer.java
@@ -64,7 +64,7 @@ class GrpcMavenBuildCustomizer implements BuildCustomizer<MavenBuild> {
 						binary.add("groupId", "io.grpc");
 						binary.add("artifactId", "protoc-gen-grpc-java");
 						binary.add("version", "${%s}".formatted(grpc.toStandardFormat()));
-						binary.add("options", "jakarta_omit,@generated=omit");
+						binary.add("options", "@generated=omit");
 					});
 				});
 			});

--- a/start-site/src/test/java/io/spring/start/site/extension/dependency/springgrpc/SpringGrpcProjectGenerationConfigurationTests.java
+++ b/start-site/src/test/java/io/spring/start/site/extension/dependency/springgrpc/SpringGrpcProjectGenerationConfigurationTests.java
@@ -75,7 +75,6 @@ class SpringGrpcProjectGenerationConfigurationTests extends AbstractExtensionTes
 					generateProtoTasks {
 						all()*.plugins {
 							grpc {
-								option 'jakarta_omit'
 								option '@generated=omit'
 							}
 						}
@@ -104,7 +103,6 @@ class SpringGrpcProjectGenerationConfigurationTests extends AbstractExtensionTes
 							all().forEach {
 								it.plugins {
 									id("grpc") {
-										option("jakarta_omit")
 										option("@generated=omit")
 									}
 								}
@@ -131,7 +129,7 @@ class SpringGrpcProjectGenerationConfigurationTests extends AbstractExtensionTes
 									<groupId>io.grpc</groupId>
 									<artifactId>protoc-gen-grpc-java</artifactId>
 									<version>${grpc.version}</version>
-									<options>jakarta_omit,@generated=omit</options>
+									<options>@generated=omit</options>
 								</binaryMavenPlugin>
 							</binaryMavenPlugins>
 						</configuration>


### PR DESCRIPTION
The `jakarta_option` was only supported by a single grpc-java release and quickly replaced by `@generated=omit` (grpc/grpc-java#11086), which is used by the current Spring gRPC version.

Also see https://github.com/spring-projects/spring-grpc/pull/225, where this option was removed from the Spring gRPC sample projects.