### PR TITLE
Update Spring AI to 1.0.3

### DIFF
--- a/start-site/src/main/resources/application.yml
+++ b/start-site/src/main/resources/application.yml
@@ -86,7 +86,7 @@ initializr:
         versionProperty: spring-ai.version
         mappings:
           - compatibilityRange: "[3.4.0,4.0.0-M1)"
-            version: 1.0.2
+            version: 1.0.3
       spring-cloud:
         groupId: org.springframework.cloud
         artifactId: spring-cloud-dependencies


### PR DESCRIPTION
Updates Spring AI BOM version to 1.0.3 for compatibility with latest patch release.

- Updated spring-ai version mapping from 1.0.2 to 1.0.3
- Maintains compatibility range [3.4.0,4.0.0-M1)

This change makes Spring AI 1.0.3 available in Spring Initializr for new projects.

---
✅ **DCO Compliance**: All commits in this PR include the required `Signed-off-by` trailer for Developer Certificate of Origin compliance.