### PR TITLE
Scroll to last added dependency on dialog reopen

### DIFF
--- a/start-client/src/components/common/dependency/Dialog.js
+++ b/start-client/src/components/common/dependency/Dialog.js
@@ -119,6 +119,20 @@ function Dialog({ onClose }) {
     setSelected(0)
     setQuery('')
     textFocus()
+    requestAnimationFrame(scrollToLastAddedDependency)
+  }
+  
+  const scrollToLastAddedDependency = () => {
+    const wrapperElement = get(wrapper, 'current')
+    const addedDependencies = wrapperElement.querySelectorAll('a.added')
+    if (!addedDependencies.length) return
+    const lastAddedDependency = addedDependencies[addedDependencies.length - 1]
+    const wrapperRect = wrapperElement.getBoundingClientRect()
+    const dependencyRect = lastAddedDependency.getBoundingClientRect()
+    wrapperElement.scrollBy({
+      top: dependencyRect.top - wrapperRect.top - 40,
+      behavior: 'smooth'
+    })
   }
 
   const updateScroll = () => {
@@ -132,7 +146,7 @@ function Dialog({ onClose }) {
       wrapperElement.scrollTop = selectedElement.offsetTop - top
     }
   }
-  
+
   const onKeyUp = event => {
     if (event.keyCode === 91 || event.keyCode === 93 || event.keyCode === 17) {
       setMultiple(false)


### PR DESCRIPTION
Ensure the dependency selection dialog automatically scrolls so the
last added dependency is aligned at the top of the list when reopened.
This improves usability when adding multiple dependencies in sequence.

![scrollToLastAddedDependency](https://github.com/user-attachments/assets/00bd573b-67dc-401d-bc05-e463e9f99d2b)

