### PR TITLE
Replace deprecated noble images from buildpacks

### DIFF
--- a/start-site/src/main/java/io/spring/start/site/extension/dependency/springkafka/SpringKafkaStreamsGradleBuildCustomizer.java
+++ b/start-site/src/main/java/io/spring/start/site/extension/dependency/springkafka/SpringKafkaStreamsGradleBuildCustomizer.java
@@ -45,7 +45,7 @@ class SpringKafkaStreamsGradleBuildCustomizer implements BuildCustomizer<GradleB
 		build.tasks().customize("bootBuildImage", (bootBuildImage) -> {
 			if (isBoot35orLater()) {
 				bootBuildImage.attribute("runImage",
-						this.quote + "paketobuildpacks/ubuntu-noble-run-base:latest" + this.quote);
+						this.quote + "paketobuildpacks/ubuntu-noble-run:latest" + this.quote);
 			}
 			else {
 				bootBuildImage.attribute("builder",

--- a/start-site/src/main/java/io/spring/start/site/extension/dependency/springkafka/SpringKafkaStreamsMavenBuildCustomizer.java
+++ b/start-site/src/main/java/io/spring/start/site/extension/dependency/springkafka/SpringKafkaStreamsMavenBuildCustomizer.java
@@ -43,7 +43,7 @@ class SpringKafkaStreamsMavenBuildCustomizer implements BuildCustomizer<MavenBui
 			.add("org.springframework.boot", "spring-boot-maven-plugin",
 					(plugin) -> plugin.configuration((configuration) -> configuration.configure("image", (image) -> {
 						if (isBoot35orLater()) {
-							image.add("runImage", "paketobuildpacks/ubuntu-noble-run-base:latest");
+							image.add("runImage", "paketobuildpacks/ubuntu-noble-run:latest");
 						}
 						else {
 							image.add("builder", "paketobuildpacks/builder-jammy-base:latest");

--- a/start-site/src/test/java/io/spring/start/site/extension/dependency/springkafka/SpringKafkaProjectGenerationConfigurationTests.java
+++ b/start-site/src/test/java/io/spring/start/site/extension/dependency/springkafka/SpringKafkaProjectGenerationConfigurationTests.java
@@ -57,7 +57,7 @@ class SpringKafkaProjectGenerationConfigurationTests extends AbstractExtensionTe
 					<artifactId>spring-boot-maven-plugin</artifactId>
 					<configuration>
 						<image>
-							<runImage>paketobuildpacks/ubuntu-noble-run-base:latest</runImage>
+							<runImage>paketobuildpacks/ubuntu-noble-run:latest</runImage>
 						</image>
 					</configuration>
 				</plugin>
@@ -79,7 +79,7 @@ class SpringKafkaProjectGenerationConfigurationTests extends AbstractExtensionTe
 		ProjectRequest request = createProjectRequest("kafka-streams");
 		assertThat(gradleBuild(request)).containsIgnoringWhitespaces("""
 				tasks.named('bootBuildImage') {
-					runImage = 'paketobuildpacks/ubuntu-noble-run-base:latest'
+					runImage = 'paketobuildpacks/ubuntu-noble-run:latest'
 				}
 				""");
 	}
@@ -99,7 +99,7 @@ class SpringKafkaProjectGenerationConfigurationTests extends AbstractExtensionTe
 		ProjectRequest request = createProjectRequest("kafka-streams");
 		assertThat(gradleKotlinDslBuild(request)).containsIgnoringWhitespaces("""
 				tasks.bootBuildImage {
-				    runImage = "paketobuildpacks/ubuntu-noble-run-base:latest"
+				    runImage = "paketobuildpacks/ubuntu-noble-run:latest"
 				}
 				""");
 	}


### PR DESCRIPTION
Closes #1975

Replaced references from `paketobuildpacks/ubuntu-noble-run-base` to `paketobuildpacks/ubuntu-noble-run`

<!--
Thanks for contributing to start.spring.io Please review the following notes before
submitting you pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Proposal for New Entries

STOP! If your contribution suggests the addition of a new entry, please do not submit it
Rather create a "New Entry Proposal" issue as we need some information from you before
proceeding.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
