### PR TITLE
Upgrade Sentry to 8.27.0 and add Spring Boot 4 Starter

### DIFF
--- a/start-site/src/main/resources/application.yml
+++ b/start-site/src/main/resources/application.yml
@@ -65,7 +65,7 @@ initializr:
         versionProperty: sentry.version
         mappings:
           - compatibilityRange: "[3.4.0,4.1.0-M1)"
-            version: 8.26.0
+            version: 8.27.0
       solace-spring-boot:
         groupId: com.solace.spring.boot
         artifactId: solace-spring-boot-bom


### PR DESCRIPTION
- Add `sentry-spring-boot-4-starter` which is only used for Spring Boot 4
	- For Spring Boot 3 `sentry-spring-boot-starter-jakarta` is used
- Bump Sentry to `8.27.0` (which has just been released, so might take a bit until it arrives in Maven repositories)

<!--
Thanks for contributing to start.spring.io Please review the following notes before
submitting you pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Proposal for New Entries

STOP! If your contribution suggests the addition of a new entry, please do not submit it
Rather create a "New Entry Proposal" issue as we need some information from you before
proceeding.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
