### PR TITLE
Upgrade to Vaadin 24.9.6

### DIFF
--- a/start-site/src/main/resources/application.yml
+++ b/start-site/src/main/resources/application.yml
@@ -180,10 +180,8 @@ initializr:
         artifactId: vaadin-bom
         versionProperty: vaadin.version
         mappings:
-          - compatibilityRange: "[3.4.0,3.5.0-M1)"
-            version: 24.7.14
-          - compatibilityRange: "[3.5.0-M1,4.0.0-M1)"
-            version: 24.9.5
+          - compatibilityRange: "[3.4.0-M1,4.0.0-M1)"
+            version: 24.9.6
     platform:
       compatibilityRange: "3.4.0"
   dependencies:


### PR DESCRIPTION
Vaadin 24.7 has end of life. 
As spring boot 3.4 is still available on https://start.spring.io/. I have tested our starter project with Vaadin 24.9.6 and Spring Boot 3.4.12, application works as expected. so let us combine both compatibility range. 