### PR TITLE
Upgrade to htmx-spring-boot 4.0.2 and 5.0.0

### DIFF
--- a/start-site/src/main/resources/application.yml
+++ b/start-site/src/main/resources/application.yml
@@ -460,10 +460,12 @@ initializr:
           groupId: io.github.wimdeblauwe
           artifactId: htmx-spring-boot
           description: Build modern user interfaces with the simplicity and power of hypertext.
-          compatibilityRange: "[3.4.0,4.0.0-M1)"
+          compatibilityRange: "[3.4.0,4.1.0-M1)"
           mappings:
             - compatibilityRange: "[3.4.0,4.0.0-M1)"
-              version: 4.0.1
+              version: 4.0.2
+            - compatibilityRange: "[4.0.0,4.1.0-M1)"
+              version: 5.0.0
           links:
             - rel: reference
               href: https://github.com/wimdeblauwe/htmx-spring-boot


### PR DESCRIPTION
Version 5.0.0 of htmx-spring-boot has been released and is now compatible with Spring Boot 4. There was also a patch release 4.0.2 for the Spring Boot 3 version.
