### PR TITLE
Upgrade to MyBatis Spring Boot Starter 4.0.0

### DIFF
--- a/start-site/src/main/resources/application.yml
+++ b/start-site/src/main/resources/application.yml
@@ -650,13 +650,15 @@ initializr:
               description: R2DBC Homepage
         - name: MyBatis Framework
           id: mybatis
-          compatibilityRange: "[3.4.0,4.0.0-M1)"
+          compatibilityRange: "[3.4.0,4.1.0-M1)"
           description: Persistence framework with support for custom SQL, stored procedures and advanced mappings. MyBatis couples objects with stored procedures or SQL statements using a XML descriptor or annotations.
           groupId: org.mybatis.spring.boot
           artifactId: mybatis-spring-boot-starter
           mappings:
             - compatibilityRange: "[3.4.0,4.0.0-M1)"
               version: 3.0.5
+            - compatibilityRange: "4.0.0"
+              version: 4.0.0
           links:
             - rel: guide
               href: https://github.com/mybatis/spring-boot-starter/wiki/Quick-Start


### PR DESCRIPTION
The MyBatis team release latest version for integrating spring-boot.

* [4.0.0](https://github.com/mybatis/spring-boot-starter/releases/tag/mybatis-spring-boot-4.0.0) for supporting spring-boot 4.

FYI:
We perform compatibility check for spring-boot available versions and passed it.
https://github.com/kazuki43zoo/mybatis-spring-boot-dev-compatibility-checker
