### PR TITLE
Distributed tracing adds the wrong dependency for Spring Boot 4.0

### DIFF
--- a/start-site/src/main/java/io/spring/start/site/extension/dependency/observability/ObservabilityDistributedTracingBuildCustomizer.java
+++ b/start-site/src/main/java/io/spring/start/site/extension/dependency/observability/ObservabilityDistributedTracingBuildCustomizer.java
@@ -54,8 +54,8 @@ class ObservabilityDistributedTracingBuildCustomizer implements BuildCustomizer<
 		}
 		if (build.dependencies().has("distributed-tracing") && isBoot4OrLater()) {
 			build.dependencies()
-				.add("spring-boot-micrometer-tracing",
-						Dependency.withCoordinates("org.springframework.boot", "spring-boot-micrometer-tracing"));
+				.add("spring-boot-micrometer-tracing-brave",
+						Dependency.withCoordinates("org.springframework.boot", "spring-boot-micrometer-tracing-brave"));
 			build.dependencies()
 				.add("spring-boot-micrometer-tracing-test",
 						Dependency.withCoordinates("org.springframework.boot", "spring-boot-micrometer-tracing-test")

--- a/start-site/src/test/java/io/spring/start/site/extension/dependency/observability/ObservabilityDistributedTracingBuildCustomizerTests.java
+++ b/start-site/src/test/java/io/spring/start/site/extension/dependency/observability/ObservabilityDistributedTracingBuildCustomizerTests.java
@@ -34,7 +34,7 @@ class ObservabilityDistributedTracingBuildCustomizerTests extends AbstractExtens
 	@Test
 	void shouldAddMicrometerTracingOnBoot4OrLater() {
 		ProjectRequest request = createProjectRequest(SupportedBootVersion.V4_0, "distributed-tracing");
-		assertThat(mavenPom(request)).hasDependency("org.springframework.boot", "spring-boot-micrometer-tracing");
+		assertThat(mavenPom(request)).hasDependency("org.springframework.boot", "spring-boot-micrometer-tracing-brave");
 		assertThat(mavenPom(request)).hasDependency("org.springframework.boot", "spring-boot-micrometer-tracing-test",
 				null, Dependency.SCOPE_TEST);
 	}
@@ -43,7 +43,7 @@ class ObservabilityDistributedTracingBuildCustomizerTests extends AbstractExtens
 	void shouldNotAddMicrometerTracingOnBootBefore4() {
 		ProjectRequest request = createProjectRequest(SupportedBootVersion.V3_5, "distributed-tracing");
 		assertThat(mavenPom(request)).doesNotHaveDependency("org.springframework.boot",
-				"spring-boot-micrometer-tracing");
+				"spring-boot-micrometer-tracing-brave");
 		assertThat(mavenPom(request)).doesNotHaveDependency("org.springframework.boot",
 				"spring-boot-micrometer-tracing-test");
 	}


### PR DESCRIPTION
Replaced spring-boot-micrometer-tracing with spring-boot-micrometer-tracing-brave for issue #2006 
<!--
Thanks for contributing to start.spring.io Please review the following notes before
submitting you pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Proposal for New Entries

STOP! If your contribution suggests the addition of a new entry, please do not submit it
Rather create a "New Entry Proposal" issue as we need some information from you before
proceeding.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
