### PR TITLE
Website has to be scrolled vertically on smaller screens

### DIFF
--- a/start-client/src/components/common/builder/Fields.js
+++ b/start-client/src/components/common/builder/Fields.js
@@ -109,7 +109,7 @@ function Fields({
               )}
             </Control>
             <Control text='Project Metadata'>
-              <div className="control control-inline">
+              <div className="control-row">
                 <FieldInput
                   id='input-group'
                   value={get(values, 'meta.group')}

--- a/start-client/src/styles/_main.scss
+++ b/start-client/src/styles/_main.scss
@@ -278,7 +278,7 @@ hr.divider {
 // Control
 
 .control {
-  padding: 0.45rem 0;
+  padding: 0.6rem 0;
   .label {
     font-weight: 600;
     font-size: $spring-font-size + 2;
@@ -302,7 +302,20 @@ hr.divider {
   input {
     color: $light-color;
     background: $light-background;
-    max-width: 520px;
+    max-width: 550px;
+  }
+}
+.control-row{
+  display: flex;
+  .control-inline{
+    max-width: 340px;
+    flex: 1 1 0;
+  }
+  .control-inline:nth-child(2) label {
+    flex: 70px 0;
+  }
+  input{
+    max-width: 250px;
   }
 }
 
@@ -572,7 +585,7 @@ button.button {
   left: 75px;
   .actions-container {
     background: $light-background-seconday;
-    padding: 20px 0.5rem;
+    padding: 18px 0.5rem;
     margin: 0 auto;
     max-width: $spring-max-width - (82 * 2);
     height: 50px;

--- a/start-client/src/styles/_responsive.scss
+++ b/start-client/src/styles/_responsive.scss
@@ -80,6 +80,18 @@
   .placeholder-button-download {
     width: 144.13px;
   }
+  .control-row {
+    display: block;
+    .control-inline{
+      max-width: none;
+    }
+    .control-inline:nth-child(2) label,label{
+      flex: 110px 0 ;
+    }
+    input {
+      max-width: 520px;
+    }
+  }
 }
 
 .not-mobile {
@@ -278,7 +290,7 @@
   hr.divider {
     display: none;
   }
-  .control-inline,
+  .control-inline,.control-row,
   .control-placeholder {
     display: block;
     label,
@@ -292,4 +304,7 @@
       margin-left: 0;
     }
   }
+  .control-row{
+    .control-inline{max-width: none;}
+  } 
 }


### PR DESCRIPTION
**Changes Made  for #1984**

1.  Put GroupId and artifactId into a single div. 
2. Reduced padding from 0.6rem to 0.45rem to fit them on one screen.

<img width="664" height="373" alt="image" src="https://github.com/user-attachments/assets/9cfc326e-632c-4ce4-b608-a39f3347777a" />


<!--
Thanks for contributing to start.spring.io Please review the following notes before
submitting you pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Proposal for New Entries

STOP! If your contribution suggests the addition of a new entry, please do not submit it
Rather create a "New Entry Proposal" issue as we need some information from you before
proceeding.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
