### PR TITLE
gRPC Maven Plugin uses deprecated protoc configuration

### DIFF
--- a/start-site/src/main/java/io/spring/start/site/extension/dependency/springgrpc/GrpcMavenBuildCustomizer.java
+++ b/start-site/src/main/java/io/spring/start/site/extension/dependency/springgrpc/GrpcMavenBuildCustomizer.java
@@ -58,7 +58,7 @@ class GrpcMavenBuildCustomizer implements BuildCustomizer<MavenBuild> {
 		plugins.add("io.github.ascopes", "protobuf-maven-plugin", (plugin) -> {
 			plugin.version(PROTOBUF_PLUGIN_VERSION);
 			plugin.configuration((configuration) -> {
-				configuration.add("protocVersion", "${%s}".formatted(protobufJava.toStandardFormat()));
+				configuration.add("protoc", "${%s}".formatted(protobufJava.toStandardFormat()));
 				configuration.add("binaryMavenPlugins", (builder) -> {
 					builder.add("binaryMavenPlugin", (binary) -> {
 						binary.add("groupId", "io.grpc");

--- a/start-site/src/test/java/io/spring/start/site/extension/dependency/springgrpc/SpringGrpcProjectGenerationConfigurationTests.java
+++ b/start-site/src/test/java/io/spring/start/site/extension/dependency/springgrpc/SpringGrpcProjectGenerationConfigurationTests.java
@@ -126,7 +126,7 @@ class SpringGrpcProjectGenerationConfigurationTests extends AbstractExtensionTes
 						<artifactId>protobuf-maven-plugin</artifactId>
 						<version>4.0.3</version>
 						<configuration>
-							<protocVersion>${protobuf-java.version}</protocVersion>
+							<protoc>${protobuf-java.version}</protoc>
 							<binaryMavenPlugins>
 								<binaryMavenPlugin>
 									<groupId>io.grpc</groupId>


### PR DESCRIPTION
The release notes of [protoc-maven-plugin 4.0.0](https://github.com/ascopes/protobuf-maven-plugin/releases/tag/v4.0.0) say:

> `<protocVersion>` is now an alias for `<protoc>` rather than vice versa. Users can continue to use the old name until v5 but are encouraged to update.

This pull request replaces the deprecated `protocVersion` element with the more future-proof `protoc` which should stay working when upgrading to version 5.x in the future.