### PR TITLE
Update test after Spring Boot 4.0.1 release

### DIFF
--- a/start-site/src/test/java/io/spring/start/site/extension/ExtensionIntegrationTests.java
+++ b/start-site/src/test/java/io/spring/start/site/extension/ExtensionIntegrationTests.java
@@ -39,9 +39,11 @@ public class ExtensionIntegrationTests extends AbstractExtensionTests {
 	@ValueSource(strings = { "maven-project", "gradle-project", "gradle-project-kotlin" })
 	void projectWithAllDependenciesCanBeGenerated(String type) {
 		InitializrMetadata metadata = getMetadata();
-		String platformVersion = metadata.getBootVersions().getDefault().getId();
-		assertThat(platformVersion).isEqualTo(SupportedBootVersion.latest().getVersion());
-		String[] dependencies = allDependencies(metadata, platformVersion);
+		Version platformVersion = Version.parse(metadata.getBootVersions().getDefault().getId());
+		Version supportedVersion = Version.parse(SupportedBootVersion.latest().getVersion());
+		assertThat(platformVersion.getMajor()).isEqualTo(supportedVersion.getMajor());
+		assertThat(platformVersion.getMinor()).isEqualTo(supportedVersion.getMinor());
+		String[] dependencies = allDependencies(metadata, platformVersion.toString());
 		ProjectRequest request = createProjectRequest(SupportedBootVersion.latest(), dependencies);
 		request.setType(type);
 		assertThatCode(() -> generateProject(request)).doesNotThrowAnyException();


### PR DESCRIPTION
`ExtensionIntegrationTests` currently fails because it is checking for the exact "4.0.0" version for the currently supported version - "4.0.1" recently got out and the test breaks as a result.