### PR TITLE
Upgrade to MyBatis Spring 4.0.1

### DIFF
--- a/start-site/src/main/resources/application.yml
+++ b/start-site/src/main/resources/application.yml
@@ -644,7 +644,7 @@ initializr:
             - compatibilityRange: "[3.5.0,4.0.0)"
               version: 3.0.5
             - compatibilityRange: "[4.0.0,4.1.0-M1)"
-              version: 4.0.0
+              version: 4.0.1
           links:
             - rel: guide
               href: https://github.com/mybatis/spring-boot-starter/wiki/Quick-Start


### PR DESCRIPTION
The MyBatis team release latest version for integrating spring-boot.

[4.0.1](https://github.com/mybatis/spring-boot-starter/releases/tag/mybatis-spring-boot-4.0.1) for bug fixing.
