### PR TITLE
Update Spring gRPC to version 1.0.1

### DIFF
--- a/start-site/src/main/resources/application.yml
+++ b/start-site/src/main/resources/application.yml
@@ -126,7 +126,7 @@ initializr:
         versionProperty: spring-grpc.version
         mappings:
           - compatibilityRange: "[4.0.0,4.1.0-M1)"
-            version: 1.0.0
+            version: 1.0.1
       spring-modulith:
         groupId: org.springframework.modulith
         artifactId: spring-modulith-bom


### PR DESCRIPTION
👋🏻 @mhalbritter,

We ( @dsyer ) recently released Spring gRPC `1.0.1`. This code proposal bumps the Spring Pulsar version from `1.0.0` to `1.0.1`.  

> [!NOTE] 
> If patch version updating is already automated or the team prefers to handle dependency changes, please disregard this PR.
