### PR TITLE
Use fixed port for Grafana LGTM

### DIFF
--- a/start-site/src/main/java/io/spring/start/site/container/SimpleDockerServiceResolver.java
+++ b/start-site/src/main/java/io/spring/start/site/container/SimpleDockerServiceResolver.java
@@ -175,7 +175,8 @@ public class SimpleDockerServiceResolver implements DockerServiceResolver {
 	private static DockerService grafanaLgtm() {
 		return DockerService.withImageAndTag("grafana/otel-lgtm")
 			.website("https://hub.docker.com/r/grafana/otel-lgtm")
-			.ports(3000, 4317, 4318)
+			.portMapping(3000, 3000) // Fixed port for web UI
+			.ports(4317, 4318) // Random ports for OTLP
 			.build();
 	}
 

--- a/start-site/src/test/resources/compose/opentelemetry.yaml
+++ b/start-site/src/test/resources/compose/opentelemetry.yaml
@@ -2,6 +2,6 @@ services:
   grafana-lgtm:
     image: 'grafana/otel-lgtm:latest'
     ports:
-      - '3000'
+      - '3000:3000'
       - '4317'
       - '4318'


### PR DESCRIPTION
## Summary

Configure Grafana LGTM with fixed port 3000:3000 for web UI access while maintaining random ports for OTLP endpoints.

### Changes
- Add `portMapping()` methods to `DockerService.Builder` to support both random and fixed ports
- Update `grafanaLgtm()` service to use fixed port 3000:3000 for the web UI
- Maintain backward compatibility with existing `ports()` methods

## Why Fixed Port for Grafana?

The Grafana web UI needs a predictable port (3000) so users can easily open it in their browser after starting the Docker Compose services. Other ports (4317, 4318 for OTLP) remain random as they don't require direct browser access.

Closes spring-io/start.spring.io#1949