### PR TITLE
Restore Okta support for Spring Boot 3.5.x

### DIFF
--- a/start-site/src/main/resources/application.yml
+++ b/start-site/src/main/resources/application.yml
@@ -572,6 +572,28 @@ initializr:
           links:
             - rel: reference
               href: https://docs.spring.io/spring-boot/{bootVersion}/reference/data/nosql.html#data.nosql.ldap
+        - name: Okta
+          id: okta
+          compatibilityRange: "[3.4.0,4.0.0-M1)"
+          description: Okta specific configuration for Spring Security/Spring Boot OAuth2 features. Enable your Spring Boot application to work with Okta via OAuth 2.0/OIDC.
+          groupId: com.okta.spring
+          artifactId: okta-spring-boot-starter
+          mappings:
+            - compatibilityRange: "[3.4.0,4.0.0-M1)"
+              version: 3.0.9
+          links:
+            - rel: guide
+              href: https://github.com/okta/samples-java-spring/tree/master/okta-hosted-login
+              description: Okta-Hosted Login Page Example
+            - rel: guide
+              href: https://github.com/okta/samples-java-spring/tree/master/custom-login
+              description: Custom Login Page Example
+            - rel: guide
+              href: https://github.com/okta/samples-java-spring/tree/master/resource-server
+              description: Okta Spring Security Resource Server Example
+            - rel: reference
+              href: https://github.com/okta/okta-spring-boot#readme
+              description: Okta Spring Boot documentation
     - name: SQL
       content:
         - name: JDBC API

--- a/start-site/src/test/java/io/spring/start/site/extension/dependency/okta/OktaHelpDocumentCustomizerTests.java
+++ b/start-site/src/test/java/io/spring/start/site/extension/dependency/okta/OktaHelpDocumentCustomizerTests.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2012 - present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.spring.start.site.extension.dependency.okta;
+
+import io.spring.initializr.web.project.ProjectRequest;
+import io.spring.start.site.extension.AbstractExtensionTests;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link OktaHelpDocumentCustomizer}.
+ *
+ * @author Stephane Nicoll
+ */
+class OktaHelpDocumentCustomizerTests extends AbstractExtensionTests {
+
+	@Test
+	void linksAddedToHelpDocumentForGradleBuild() {
+		assertHelpDocument("gradle-build", "okta").contains("## OAuth 2.0 and OIDC with Okta",
+				"If you don't have a free Okta developer account, you can create one with [the Okta CLI](https://cli.okta.com):",
+				"You can also use the Okta Admin Console to create your app. See [Create a Spring Boot App](https://developer.okta.com/docs/guides/sign-into-web-app-redirect/spring-boot/main/) for more information.");
+	}
+
+	@Test
+	void linksAddedToHelpDocumentForMavenBuild() {
+		assertHelpDocument("maven-build", "okta").contains("## OAuth 2.0 and OIDC with Okta",
+				"If you don't have a free Okta developer account, you can create one with [the Okta CLI](https://cli.okta.com):",
+				"You can also use the Okta Admin Console to create your app. See [Create a Spring Boot App](https://developer.okta.com/docs/guides/sign-into-web-app-redirect/spring-boot/main/) for more information.");
+	}
+
+	@Test
+	void linksNotAddedToHelpDocumentForBuildWithoutOkta() {
+		assertHelpDocument("gradle-build").noneMatch((line) -> line.contains("Okta"));
+	}
+
+	private org.assertj.core.api.ListAssert<String> assertHelpDocument(String type, String... dependencies) {
+		ProjectRequest request = createProjectRequest(dependencies);
+		request.setType(type);
+		return assertThat(helpDocument(request)).lines();
+	}
+
+}


### PR DESCRIPTION
- Restore Okta dependency with compatibility range [3.4.0,4.0.0-M1)
- Update to Okta Spring Boot starter version 3.0.9
- Restore OktaHelpDocumentCustomizerTests
- Add all Okta guide links and reference documentation

<!--
Thanks for contributing to start.spring.io Please review the following notes before
submitting you pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Proposal for New Entries

STOP! If your contribution suggests the addition of a new entry, please do not submit it
Rather create a "New Entry Proposal" issue as we need some information from you before
proceeding.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
