### PR TITLE
Update Okta Spring Boot to 3.0.10 with Spring Boot 4.x support

### DIFF
--- a/start-site/src/main/resources/application.yml
+++ b/start-site/src/main/resources/application.yml
@@ -587,13 +587,13 @@ initializr:
               href: https://docs.spring.io/spring-boot/{bootVersion}/reference/data/nosql.html#data.nosql.ldap
         - name: Okta
           id: okta
-          compatibilityRange: "[3.5.0,4.0.0)"
+          compatibilityRange: "[3.5.0,)"
           description: Okta specific configuration for Spring Security/Spring Boot OAuth2 features. Enable your Spring Boot application to work with Okta via OAuth 2.0/OIDC.
           groupId: com.okta.spring
           artifactId: okta-spring-boot-starter
           mappings:
-            - compatibilityRange: "[3.5.0,4.0.0)"
-              version: 3.0.9
+            - compatibilityRange: "[3.5.0,)"
+              version: 3.0.10
           links:
             - rel: guide
               href: https://github.com/okta/samples-java-spring/tree/master/okta-hosted-login


### PR DESCRIPTION
## Update Okta Spring Boot to 3.0.10 with Spring Boot 4.x Support

### Summary
Updates the start.spring.io dependency configuration to recommend **Okta Spring Boot 3.0.10**, which now provides full support for **Spring Boot 4.x** alongside existing Spring Boot 3.5.x support.

### Changes
- Updated Okta Spring Boot compatibility range from `[3.5.0,4.0.0)` to `[3.5.0,)` (supports 3.5.x, 4.x, and future versions)
- Updated recommended version from `3.0.9` to `3.0.10`

### Why This Matters
**3.0.9 was broken for Spring Boot 4.x users** due to a `ClassNotFoundException` when importing `OAuth2ClientProperties`, which doesn't exist in Spring Boot 4.0+.

**3.0.10 fixes this** by using reflection-based dynamic class loading instead of direct imports, allowing graceful fallback when the class is unavailable. This single release now supports:
- ✅ Spring Boot 3.5.0+ (all 3.5.x versions)
- ✅ Spring Boot 4.0.0+