### PR TITLE
Upgrade to Datasource Micrometer 1.3.1 and 2.1.1

### DIFF
--- a/start-site/src/main/resources/application.yml
+++ b/start-site/src/main/resources/application.yml
@@ -44,9 +44,9 @@ initializr:
         versionProperty: datasource-micrometer.version
         mappings:
           - compatibilityRange: "[3.5.0,4.0.0)"
-            version: 1.3.0
+            version: 1.3.1
           - compatibilityRange: "[4.0.0,4.1.0-M1)"
-            version: 2.1.0
+            version: 2.1.1
       codecentric-spring-boot-admin:
         groupId: de.codecentric
         artifactId: spring-boot-admin-dependencies


### PR DESCRIPTION
I have released new versions [1.3.1](https://github.com/jdbc-observations/datasource-micrometer/releases/tag/v1.3.1) and [2.1.1](https://github.com/jdbc-observations/datasource-micrometer/releases/tag/v2.1.1).