### PR TITLE
Generate test app when Spring AI Vector Store Typesense is selected

### DIFF
--- a/start-site/src/main/java/io/spring/start/site/container/SimpleDockerServiceResolver.java
+++ b/start-site/src/main/java/io/spring/start/site/container/SimpleDockerServiceResolver.java
@@ -60,6 +60,7 @@ public class SimpleDockerServiceResolver implements DockerServiceResolver {
 		this.dockerServices.put("redis", redis());
 		this.dockerServices.put("redisStack", redisStack());
 		this.dockerServices.put("sqlServer", sqlServer());
+		this.dockerServices.put("typesense", typesense());
 		this.dockerServices.put("weaviate", weaviate());
 		this.dockerServices.put("zipkin", zipkin());
 	}
@@ -246,6 +247,13 @@ public class SimpleDockerServiceResolver implements DockerServiceResolver {
 		return DockerService.withImageAndTag("mcr.microsoft.com/mssql/server")
 			.website("https://mcr.microsoft.com/en-us/product/mssql/server/about/")
 			.randomPort(1433)
+			.build();
+	}
+
+	private static DockerService typesense() {
+		return DockerService.withImageAndTag("typesense/typesense")
+			.website("https://hub.docker.com/r/typesense/typesense")
+			.randomPort(8108)
 			.build();
 	}
 

--- a/start-site/src/main/java/io/spring/start/site/container/Testcontainers.java
+++ b/start-site/src/main/java/io/spring/start/site/container/Testcontainers.java
@@ -24,6 +24,7 @@ import io.spring.initializr.generator.version.VersionRange;
  * Manages testcontainers with their container names and modules.
  *
  * @author Moritz Halbritter
+ * @author Eddú Meléndez
  */
 public class Testcontainers {
 
@@ -113,6 +114,9 @@ public class Testcontainers {
 			case RABBITMQ -> (hasTc2())
 					? Container.of("org.testcontainers.rabbitmq.RabbitMQContainer", false, "testcontainers-rabbitmq")
 					: Container.of("org.testcontainers.containers.RabbitMQContainer", false, "rabbitmq");
+			case TYPESENSE -> (hasTc2())
+					? Container.of("org.testcontainers.typesense.TypesenseContainer", false, "testcontainers-typesense")
+					: Container.of("org.testcontainers.typesense.TypesenseContainer", false, "typesense");
 			case WEAVIATE -> (hasTc2())
 					? Container.of("org.testcontainers.weaviate.WeaviateContainer", false, "testcontainers-weaviate")
 					: Container.of("org.testcontainers.weaviate.WeaviateContainer", false, "weaviate");
@@ -221,6 +225,10 @@ public class Testcontainers {
 		 * RabbitMQ.
 		 */
 		RABBITMQ,
+		/**
+		 * Typesense.
+		 */
+		TYPESENSE,
 		/**
 		 * Weaviate.
 		 */

--- a/start-site/src/main/java/io/spring/start/site/extension/dependency/springai/SpringAiTypesenseProjectGenerationConfiguration.java
+++ b/start-site/src/main/java/io/spring/start/site/extension/dependency/springai/SpringAiTypesenseProjectGenerationConfiguration.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2012 - present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.spring.start.site.extension.dependency.springai;
+
+import io.spring.initializr.generator.condition.ConditionalOnRequestedDependency;
+import io.spring.initializr.generator.project.ProjectGenerationConfiguration;
+import io.spring.start.site.container.ComposeFileCustomizer;
+import io.spring.start.site.container.DockerServiceResolver;
+import io.spring.start.site.container.ServiceConnections.ServiceConnection;
+import io.spring.start.site.container.ServiceConnectionsCustomizer;
+import io.spring.start.site.container.Testcontainers;
+import io.spring.start.site.container.Testcontainers.Container;
+import io.spring.start.site.container.Testcontainers.SupportedContainer;
+
+import org.springframework.context.annotation.Bean;
+
+/**
+ * Configuration for generation of projects that depend on Typesense.
+ *
+ * @author Eddú Meléndez
+ */
+@ProjectGenerationConfiguration
+@ConditionalOnRequestedDependency("spring-ai-vectordb-typesense")
+class SpringAiTypesenseProjectGenerationConfiguration {
+
+	@Bean
+	@ConditionalOnRequestedDependency("testcontainers")
+	ServiceConnectionsCustomizer typesenseServiceConnectionsCustomizer(DockerServiceResolver serviceResolver,
+			Testcontainers testcontainers) {
+		Container container = testcontainers.getContainer(SupportedContainer.TYPESENSE);
+		return (serviceConnections) -> serviceResolver
+			.doWith("typesense", (service) -> serviceConnections.addServiceConnection(
+					ServiceConnection.ofContainer("typesense", service, container.className(), container.generic())));
+	}
+
+	@Bean
+	@ConditionalOnRequestedDependency("docker-compose")
+	ComposeFileCustomizer typesenseComposeFileCustomizer(DockerServiceResolver serviceResolver) {
+		return (composeFile) -> serviceResolver.doWith("typesense",
+				(service) -> composeFile.services()
+					.add("typesense", service.andThen((builder) -> builder.environment("TYPESENSE_API_KEY", "secret")
+						.environment("TYPESENSE_DATA_DIR", "/tmp"))));
+	}
+
+}

--- a/start-site/src/main/java/io/spring/start/site/extension/dependency/testcontainers/TestcontainersModuleRegistry.java
+++ b/start-site/src/main/java/io/spring/start/site/extension/dependency/testcontainers/TestcontainersModuleRegistry.java
@@ -114,6 +114,9 @@ abstract class TestcontainersModuleRegistry {
 		builders.add(onDependencies("spring-ai-vectordb-qdrant")
 			.customizeBuild(addModule("qdrant", testcontainers, SupportedContainer.QDRANT))
 			.customizeHelpDocument(addReferenceLink("Qdrant Module", "testcontainers/")));
+		builders.add(onDependencies("spring-ai-vectordb-typesense")
+			.customizeBuild(addModule("typesense", testcontainers, SupportedContainer.TYPESENSE))
+			.customizeHelpDocument(addReferenceLink("Typesense Module", "testcontainers/")));
 		builders.add(onDependencies("spring-ai-vectordb-weaviate")
 			.customizeBuild(addModule("weaviate", testcontainers, SupportedContainer.WEAVIATE))
 			.customizeHelpDocument(addReferenceLink("Weaviate Module", "testcontainers/")));

--- a/start-site/src/main/resources/META-INF/spring.factories
+++ b/start-site/src/main/resources/META-INF/spring.factories
@@ -41,6 +41,7 @@ io.spring.start.site.extension.dependency.springai.SpringAiOllamaProjectGenerati
 io.spring.start.site.extension.dependency.springai.SpringAiProjectGenerationConfiguration,\
 io.spring.start.site.extension.dependency.springai.SpringAiQdrantProjectGenerationConfiguration,\
 io.spring.start.site.extension.dependency.springai.SpringAiTestcontainersProjectGenerationConfiguration,\
+io.spring.start.site.extension.dependency.springai.SpringAiTypesenseProjectGenerationConfiguration,\
 io.spring.start.site.extension.dependency.springai.SpringAiWeaviateProjectGenerationConfiguration,\
 io.spring.start.site.extension.dependency.springamqp.SpringAmqpProjectGenerationConfiguration,\
 io.spring.start.site.extension.dependency.springazure.SpringAzureDockerComposeProjectGenerationConfiguration,\

--- a/start-site/src/test/java/io/spring/start/site/extension/dependency/springai/SpringAiTypesenseProjectGenerationConfigurationTests.java
+++ b/start-site/src/test/java/io/spring/start/site/extension/dependency/springai/SpringAiTypesenseProjectGenerationConfigurationTests.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2012 - present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.spring.start.site.extension.dependency.springai;
+
+import io.spring.initializr.generator.test.project.ProjectStructure;
+import io.spring.initializr.web.project.ProjectRequest;
+import io.spring.start.site.SupportedBootVersion;
+import io.spring.start.site.extension.AbstractExtensionTests;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.core.io.ClassPathResource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link SpringAiWeaviateProjectGenerationConfiguration}
+ *
+ * @author Eddú Meléndez
+ */
+class SpringAiTypesenseProjectGenerationConfigurationTests extends AbstractExtensionTests {
+
+	private static final SupportedBootVersion BOOT_VERSION = SupportedBootVersion.V3_5;
+
+	@Test
+	void doesNothingWithoutDockerCompose() {
+		ProjectRequest request = createProjectRequest(BOOT_VERSION, "web", "spring-ai-vectordb-typesense");
+		ProjectStructure structure = generateProject(request);
+		assertThat(structure.getProjectDirectory().resolve("compose.yaml")).doesNotExist();
+	}
+
+	@Test
+	void createsTypesenseService() {
+		ProjectRequest request = createProjectRequest(BOOT_VERSION, "docker-compose", "spring-ai-vectordb-typesense");
+		assertThat(composeFile(request)).hasSameContentAs(new ClassPathResource("compose/typesense.yaml"));
+	}
+
+}

--- a/start-site/src/test/java/io/spring/start/site/extension/dependency/testcontainers/TestcontainersProjectGenerationConfigurationTests.java
+++ b/start-site/src/test/java/io/spring/start/site/extension/dependency/testcontainers/TestcontainersProjectGenerationConfigurationTests.java
@@ -84,6 +84,7 @@ class TestcontainersProjectGenerationConfigurationTests extends AbstractExtensio
 				Arguments.arguments("spring-ai-vectordb-milvus", "milvus"),
 				Arguments.arguments("spring-ai-vectordb-mongodb-atlas", "mongodb"),
 				Arguments.arguments("spring-ai-vectordb-qdrant", "qdrant"),
+				Arguments.arguments("spring-ai-vectordb-typesense", "typesense"),
 				Arguments.arguments("spring-ai-vectordb-weaviate", "weaviate"));
 	}
 

--- a/start-site/src/test/resources/compose/typesense.yaml
+++ b/start-site/src/test/resources/compose/typesense.yaml
@@ -1,0 +1,8 @@
+services:
+  typesense:
+    image: 'typesense/typesense:latest'
+    environment:
+      - 'TYPESENSE_API_KEY=secret'
+      - 'TYPESENSE_DATA_DIR=/tmp'
+    ports:
+      - '8108'


### PR DESCRIPTION
Spring AI offers support for Typesense Service Connection via
Docker Compose and Testcontainers.

Signed-off-by: Eddú Meléndez <eddu.melendez@gmail.com>
