### PR TITLE
Add Neo4j to Spring Modulith

### DIFF
--- a/start-site/src/main/java/io/spring/start/site/extension/dependency/springmodulith/SpringModulithBuildCustomizer.java
+++ b/start-site/src/main/java/io/spring/start/site/extension/dependency/springmodulith/SpringModulithBuildCustomizer.java
@@ -33,13 +33,14 @@ import io.spring.initializr.generator.spring.build.BuildCustomizer;
  *
  * @author Oliver Drotbohm
  * @author Stephane Nicoll
+ * @author Eddú Meléndez
  */
 class SpringModulithBuildCustomizer implements BuildCustomizer<Build> {
 
 	private static final Collection<String> OBSERVABILITY_DEPENDENCIES = List.of("actuator", "datadog", "graphite",
 			"influx", "new-relic", "otlp-metrics", "prometheus", "wavefront", "zipkin");
 
-	private static final Collection<String> PERSISTENCE = List.of("jdbc", "jpa", "mongodb");
+	private static final Collection<String> PERSISTENCE = List.of("jdbc", "jpa", "mongodb", "neo4j");
 
 	private static final Collection<String> BROKERS = List.of("activemq", "amqp", "artemis", "kafka");
 

--- a/start-site/src/test/java/io/spring/start/site/extension/dependency/springmodulith/SpringModulithBuildCustomizerTests.java
+++ b/start-site/src/test/java/io/spring/start/site/extension/dependency/springmodulith/SpringModulithBuildCustomizerTests.java
@@ -34,6 +34,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * Tests for {@link SpringModulithBuildCustomizer}.
  *
  * @author Oliver Drotbohm
+ * @author Eddú Meléndez
  */
 class SpringModulithBuildCustomizerTests extends AbstractExtensionTests {
 
@@ -65,7 +66,7 @@ class SpringModulithBuildCustomizerTests extends AbstractExtensionTests {
 	}
 
 	@ParameterizedTest
-	@ValueSource(strings = { "jdbc", "jpa", "mongodb" })
+	@ValueSource(strings = { "jdbc", "jpa", "mongodb", "neo4j" })
 	void presenceOfSpringDataModuleAddsModuleEventStarter(String store) {
 		Build build = createBuild("modulith");
 		build.dependencies().add("data-" + store);


### PR DESCRIPTION
Spring Modulith supports Neo4j as a persistence store.

Signed-off-by: Eddú Meléndez <eddu.melendez@gmail.com>
