### PR TITLE
Upgrade SpringDoc OpenAPI to 2.8.16 and 3.0.2

### DIFF
--- a/start-site/src/main/resources/application.yml
+++ b/start-site/src/main/resources/application.yml
@@ -471,28 +471,11 @@ initializr:
               href: https://github.com/wimdeblauwe/htmx-spring-boot
             - rel: guide
               href: https://www.youtube.com/watch?v=j-rfPoXe5aE
-        - name: SpringDoc OpenAPI (WebMVC UI)
-          id: springdoc-openapi-webmvc
+        - name: SpringDoc OpenAPI
+          id: springdoc-openapi
           groupId: org.springdoc
           artifactId: springdoc-openapi-starter-webmvc-ui
-          description: Add OpenAPI / Swagger documentation to web-based Spring WebMVC applications.
-          starter: false
-          compatibilityRange: "[3.5.0,4.1.0-M1)"
-          mappings:
-            - compatibilityRange: "[3.5.0,4.0.0)"
-              version: 2.8.16
-            - compatibilityRange: "[4.0.0,4.1.0-M1)"
-              version: 3.0.2
-          links:
-            - rel: reference
-              href: https://springdoc.org/
-            - rel: guide
-              href: https://github.com/springdoc/springdoc-openapi-demos/
-        - name: SpringDoc OpenAPI (WebFlux UI)
-          id: springdoc-openapi-webflux
-          groupId: org.springdoc
-          artifactId: springdoc-openapi-starter-webflux-ui
-          description: Add OpenAPI / Swagger documentation to web-based Spring WebFlux applications.
+          description: Add OpenAPI / Swagger documentation to web-based Spring applications.
           starter: false
           compatibilityRange: "[3.5.0,4.1.0-M1)"
           mappings:


### PR DESCRIPTION
Updates `springdoc-openapi` metadata to align with Spring Boot compatibility ranges:
- Version `2.8.16`: Set for range [3.5.0, 4.0.0)
- Version `3.0.2:` Set for range [4.0.0, 4.1.0-M1)

This ensures the Initializr provides the `latest` dependency versions for users bootstrapping Spring Boot 3.5.x and 4.x projects.