### PR TITLE
Upgrade to Datasource Micrometer 1.4.0 and 2.2.0

### DIFF
--- a/start-site/src/main/resources/application.yml
+++ b/start-site/src/main/resources/application.yml
@@ -44,9 +44,9 @@ initializr:
         versionProperty: datasource-micrometer.version
         mappings:
           - compatibilityRange: "[3.5.0,4.0.0)"
-            version: 1.3.1
+            version: 1.4.0
           - compatibilityRange: "[4.0.0,4.1.0-M1)"
-            version: 2.1.1
+            version: 2.2.0
       codecentric-spring-boot-admin:
         groupId: de.codecentric
         artifactId: spring-boot-admin-dependencies


### PR DESCRIPTION
I have released new versions [1.4.0](https://github.com/jdbc-observations/datasource-micrometer/releases/tag/v1.4.0) and [2.2.0](https://github.com/jdbc-observations/datasource-micrometer/releases/tag/v2.2.0).
