### PR TITLE
Adapt to RabbitMQ behavior moving to spring-boot-starter-rabbitmq

### DIFF
--- a/start-site/src/main/java/io/spring/start/site/extension/dependency/springamqp/SpringAmqpProjectGenerationConfiguration.java
+++ b/start-site/src/main/java/io/spring/start/site/extension/dependency/springamqp/SpringAmqpProjectGenerationConfiguration.java
@@ -39,12 +39,12 @@ import org.springframework.context.annotation.Configuration;
 class SpringAmqpProjectGenerationConfiguration {
 
 	@Configuration(proxyBeanMethods = false)
-	@ConditionalOnRequestedDependency("amqp")
-	static class AmqpConfiguration {
+	@ConditionalOnRequestedDependency("rabbitmq")
+	static class RabbitMqConfiguration {
 
 		@Bean
 		@ConditionalOnPlatformVersion("[3.5.0,4.0.0-RC1]")
-		SpringRabbitTestBuildCustomizer springAmqpTestBuildCustomizer() {
+		SpringRabbitTestBuildCustomizer springRabbitTestBuildCustomizer() {
 			return new SpringRabbitTestBuildCustomizer();
 		}
 
@@ -71,9 +71,9 @@ class SpringAmqpProjectGenerationConfiguration {
 
 	}
 
-	@ConditionalOnRequestedDependency("amqp-streams")
+	@ConditionalOnRequestedDependency("rabbitmq-streams")
 	@Configuration(proxyBeanMethods = false)
-	static class AmqpStreamsConfiguration {
+	static class RabbityMqStreamsConfiguration {
 
 		@Bean
 		SpringRabbitStreamsBuildCustomizer springRabbitStreamsBuildCustomizer() {

--- a/start-site/src/main/java/io/spring/start/site/extension/dependency/springamqp/SpringRabbitStreamsBuildCustomizer.java
+++ b/start-site/src/main/java/io/spring/start/site/extension/dependency/springamqp/SpringRabbitStreamsBuildCustomizer.java
@@ -28,7 +28,7 @@ class SpringRabbitStreamsBuildCustomizer implements BuildCustomizer<Build> {
 
 	@Override
 	public void customize(Build build) {
-		build.dependencies().add("amqp");
+		build.dependencies().add("rabbitmq");
 	}
 
 }

--- a/start-site/src/main/java/io/spring/start/site/extension/dependency/springcloud/SpringCloudStreamBuildCustomizer.java
+++ b/start-site/src/main/java/io/spring/start/site/extension/dependency/springcloud/SpringCloudStreamBuildCustomizer.java
@@ -38,7 +38,7 @@ class SpringCloudStreamBuildCustomizer implements BuildCustomizer<Build> {
 	@Override
 	public void customize(Build build) {
 		if (hasDependency("cloud-stream", build) || hasDependency("cloud-bus", build)) {
-			if (hasDependency("amqp", build)) {
+			if (hasDependency("rabbitmq", build)) {
 				build.dependencies()
 					.add("cloud-stream-binder-rabbit", "org.springframework.cloud", "spring-cloud-stream-binder-rabbit",
 							DependencyScope.COMPILE);

--- a/start-site/src/main/java/io/spring/start/site/extension/dependency/springintegration/SpringIntegrationModuleRegistry.java
+++ b/start-site/src/main/java/io/spring/start/site/extension/dependency/springintegration/SpringIntegrationModuleRegistry.java
@@ -42,7 +42,7 @@ abstract class SpringIntegrationModuleRegistry {
 		List<Builder> builders = new ArrayList<>();
 		builders.add(onDependencies("activemq", "artemis").customizeBuild(addDependency("jms"))
 			.customizeHelpDocument(addReferenceLink("JMS Module", "jms")));
-		builders.add(onDependencies("amqp", "amqp-streams").customizeBuild(addDependency("amqp"))
+		builders.add(onDependencies("rabbitmq", "rabbitmq-streams").customizeBuild(addDependency("amqp"))
 			.customizeHelpDocument(addReferenceLink("AMQP Module", "amqp")));
 		builders.add(onDependencies("data-jdbc", "jdbc").customizeBuild(addDependency("jdbc"))
 			.customizeHelpDocument(addReferenceLink("JDBC Module", "jdbc")));

--- a/start-site/src/main/java/io/spring/start/site/extension/dependency/springmodulith/SpringModulithBuildCustomizer.java
+++ b/start-site/src/main/java/io/spring/start/site/extension/dependency/springmodulith/SpringModulithBuildCustomizer.java
@@ -42,7 +42,7 @@ class SpringModulithBuildCustomizer implements BuildCustomizer<Build> {
 
 	private static final Collection<String> PERSISTENCE = List.of("jdbc", "jpa", "mongodb", "neo4j");
 
-	private static final Collection<String> BROKERS = List.of("activemq", "amqp", "artemis", "kafka");
+	private static final Collection<String> BROKERS = List.of("activemq", "artemis", "kafka", "rabbitmq");
 
 	@Override
 	public void customize(Build build) {
@@ -94,8 +94,9 @@ class SpringModulithBuildCustomizer implements BuildCustomizer<Build> {
 
 	private String getModulithBrokerKey(String broker) {
 		return switch (broker) {
-			case "kafka", "amqp" -> broker;
 			case "artemis", "activemq" -> "jms";
+			case "kafka" -> broker;
+			case "rabbitmq" -> "amqp";
 			default -> throw new IllegalArgumentException("Unsupported broker!");
 		};
 	}

--- a/start-site/src/main/java/io/spring/start/site/extension/dependency/testcontainers/TestcontainersModuleRegistry.java
+++ b/start-site/src/main/java/io/spring/start/site/extension/dependency/testcontainers/TestcontainersModuleRegistry.java
@@ -48,7 +48,7 @@ abstract class TestcontainersModuleRegistry {
 		builders.add(onDependencies("artemis")
 			.customizeBuild(addModule("activemq", testcontainers, SupportedContainer.ARTEMIS))
 			.customizeHelpDocument(addReferenceLink("ActiveMQ Module", "activemq/")));
-		builders.add(onDependencies("amqp", "amqp-streams")
+		builders.add(onDependencies("rabbitmq", "rabbitmq-streams")
 			.customizeBuild(addModule("rabbitmq", testcontainers, SupportedContainer.RABBITMQ))
 			.customizeHelpDocument(addReferenceLink("RabbitMQ Module", "rabbitmq/")));
 		builders.add(onDependencies("cloud-gcp", "cloud-gcp-pubsub").customizeBuild(addModule("gcloud", testcontainers))

--- a/start-site/src/main/resources/application.yml
+++ b/start-site/src/main/resources/application.yml
@@ -979,8 +979,11 @@ initializr:
             - rel: reference
               href: https://docs.spring.io/spring-boot/{bootVersion}/reference/messaging/spring-integration.html
         - name: Spring for RabbitMQ
-          id: amqp
+          id: rabbitmq
           description: Gives your applications a common platform to send and receive messages, and your messages a safe place to live until received.
+          mappings:
+            - compatibilityRange: "[3.5.0,4.1.0-M3)"
+              artifact-id: spring-boot-starter-amqp
           links:
             - rel: guide
               href: https://spring.io/guides/gs/messaging-rabbitmq/
@@ -988,7 +991,7 @@ initializr:
             - rel: reference
               href: https://docs.spring.io/spring-boot/{bootVersion}/reference/messaging/amqp.html
         - name: Spring for RabbitMQ Streams
-          id: amqp-streams
+          id: rabbitmq-streams
           description: Building stream processing applications with RabbitMQ.
           groupId: org.springframework.amqp
           artifactId: spring-rabbit-stream

--- a/start-site/src/test/java/io/spring/start/site/extension/dependency/springamqp/SpringAmqpProjectGenerationConfigurationTests.java
+++ b/start-site/src/test/java/io/spring/start/site/extension/dependency/springamqp/SpringAmqpProjectGenerationConfigurationTests.java
@@ -44,32 +44,44 @@ class SpringAmqpProjectGenerationConfigurationTests extends AbstractExtensionTes
 		.withConfiguration(SpringAmqpProjectGenerationConfiguration.class);
 
 	@Test
-	void springAmqpTestWithAmqp() {
-		MutableProjectDescription description = new MutableProjectDescription();
-		description.setPlatformVersion(Version.parse(SupportedBootVersion.V3_5.getVersion()));
-		description.addDependency("amqp", mock(Dependency.class));
-		this.projectTester.configure(description, (context) -> assertThat(context).getBeans(BuildCustomizer.class)
-			.containsKeys("springAmqpTestBuildCustomizer"));
+	void amqpStarterIsAddedPriorToSpringBoot41() {
+		ProjectRequest request = createProjectRequest(SupportedBootVersion.V4_0, "rabbitmq");
+		assertThat(mavenPom(request)).hasDependency("org.springframework.boot", "spring-boot-starter-amqp");
 	}
 
 	@Test
-	void springAmqpTestWithoutAmqp() {
+	void rabbitMqStarterIsAddedAsOfSpringBoot41() {
+		ProjectRequest request = createProjectRequest(SupportedBootVersion.V4_1, "rabbitmq");
+		assertThat(mavenPom(request)).hasDependency("org.springframework.boot", "spring-boot-starter-rabbitmq");
+	}
+
+	@Test
+	void springRabbitTestWithRabbitMq() {
+		MutableProjectDescription description = new MutableProjectDescription();
+		description.setPlatformVersion(Version.parse(SupportedBootVersion.V3_5.getVersion()));
+		description.addDependency("rabbitmq", mock(Dependency.class));
+		this.projectTester.configure(description, (context) -> assertThat(context).getBeans(BuildCustomizer.class)
+			.containsKeys("springRabbitTestBuildCustomizer"));
+	}
+
+	@Test
+	void springRabbitTestWithoutRabbitMq() {
 		MutableProjectDescription description = new MutableProjectDescription();
 		description.addDependency("another", mock(Dependency.class));
 		this.projectTester.configure(description, (context) -> assertThat(context).getBeans(BuildCustomizer.class)
-			.doesNotContainKeys("springAmqpTestBuildCustomizer"));
+			.doesNotContainKeys("springRabbitTestBuildCustomizer"));
 	}
 
 	@Test
-	void springAmqpWithoutDockerCompose() {
-		ProjectRequest request = createProjectRequest("web", "amqp");
+	void springRabbitMqWithoutDockerCompose() {
+		ProjectRequest request = createProjectRequest("web", "rabbitmq");
 		ProjectStructure structure = generateProject(request);
 		assertThat(structure.getProjectDirectory().resolve("compose.yaml")).doesNotExist();
 	}
 
 	@Test
-	void springAmqpWithDockerCompose() {
-		ProjectRequest request = createProjectRequest("docker-compose", "amqp");
+	void springRabbitMqWithDockerCompose() {
+		ProjectRequest request = createProjectRequest("docker-compose", "rabbitmq");
 		assertThat(composeFile(request)).hasSameContentAs(new ClassPathResource("compose/rabbitmq.yaml"));
 	}
 

--- a/start-site/src/test/java/io/spring/start/site/extension/dependency/springamqp/SpringRabbitStreamsBuildCustomizerTests.java
+++ b/start-site/src/test/java/io/spring/start/site/extension/dependency/springamqp/SpringRabbitStreamsBuildCustomizerTests.java
@@ -31,16 +31,16 @@ import static org.assertj.core.api.Assertions.assertThat;
 class SpringRabbitStreamsBuildCustomizerTests extends AbstractExtensionTests {
 
 	@Test
-	void shouldDoNothingIfAmqpStreamsIsNotSelected() {
+	void shouldDoNothingIfRabbitMqStreamsIsNotSelected() {
 		ProjectRequest project = createProjectRequest("web");
-		Dependency amqp = getDependency("amqp");
+		Dependency amqp = getDependency("rabbitmq");
 		assertThat(mavenPom(project)).doesNotHaveDependency(amqp.getGroupId(), amqp.getArtifactId());
 	}
 
 	@Test
-	void shouldAddAmqpIfAmqpStreamsIsSelected() {
-		ProjectRequest project = createProjectRequest("amqp-streams");
-		assertThat(mavenPom(project)).hasDependency(getDependency("amqp"));
+	void shouldAddAmqpIfRabbitMqStreamsIsSelected() {
+		ProjectRequest project = createProjectRequest("rabbitmq-streams");
+		assertThat(mavenPom(project)).hasDependency(getDependency("rabbitmq"));
 	}
 
 }

--- a/start-site/src/test/java/io/spring/start/site/extension/dependency/springamqp/SpringRabbitTestBuildCustomizerTests.java
+++ b/start-site/src/test/java/io/spring/start/site/extension/dependency/springamqp/SpringRabbitTestBuildCustomizerTests.java
@@ -34,14 +34,14 @@ class SpringRabbitTestBuildCustomizerTests extends AbstractExtensionTests {
 
 	@Test
 	void shouldAddSpringRabbitTest() {
-		ProjectRequest request = createProjectRequest(SupportedBootVersion.V3_5, "amqp");
+		ProjectRequest request = createProjectRequest(SupportedBootVersion.V3_5, "rabbitmq");
 		assertThat(mavenPom(request)).hasDependency("org.springframework.amqp", "spring-rabbit-test", null,
 				Dependency.SCOPE_TEST);
 	}
 
 	@Test
 	void shouldNotAddSpringRabbitTestForBoot4() {
-		ProjectRequest request = createProjectRequest(SupportedBootVersion.V4_0, "amqp");
+		ProjectRequest request = createProjectRequest(SupportedBootVersion.V4_0, "rabbitmq");
 		assertThat(mavenPom(request)).doesNotHaveDependency("org.springframework.amqp", "spring-rabbit-test");
 	}
 

--- a/start-site/src/test/java/io/spring/start/site/extension/dependency/springcloud/SpringCloudStreamBuildCustomizerTests.java
+++ b/start-site/src/test/java/io/spring/start/site/extension/dependency/springcloud/SpringCloudStreamBuildCustomizerTests.java
@@ -51,10 +51,10 @@ class SpringCloudStreamBuildCustomizerTests extends AbstractExtensionTests {
 			"spring-cloud-stream-test-binder", null, Dependency.SCOPE_TEST);
 
 	@Test
-	void springCloudStreamWithRabbit() {
-		ProjectRequest request = createProjectRequest(BOOT_VERSION, "cloud-stream", "amqp");
+	void springCloudStreamWithRabbitMq() {
+		ProjectRequest request = createProjectRequest(BOOT_VERSION, "cloud-stream", "rabbitmq");
 		assertThat(mavenPom(request)).hasDependency(getDependency(BOOT_VERSION, "cloud-stream"))
-			.hasDependency(getDependency(BOOT_VERSION, "amqp"))
+			.hasDependency(getDependency(BOOT_VERSION, "rabbitmq"))
 			.hasDependency(RABBIT_BINDER)
 			.hasDependency(Dependency.createSpringBootStarter("test", Dependency.SCOPE_TEST))
 			.hasDependency(TEST_BINDER)
@@ -94,24 +94,25 @@ class SpringCloudStreamBuildCustomizerTests extends AbstractExtensionTests {
 
 	@Test
 	void springCloudStreamWithAllBinders() {
-		ProjectRequest request = createProjectRequest(BOOT_VERSION, "cloud-stream", "amqp", "kafka", "kafka-streams");
+		ProjectRequest request = createProjectRequest(BOOT_VERSION, "cloud-stream", "kafka", "kafka-streams",
+				"rabbitmq");
 		assertThat(mavenPom(request)).hasDependency(getDependency(BOOT_VERSION, "cloud-stream"))
-			.hasDependency(getDependency(BOOT_VERSION, "amqp"))
 			.hasDependency(getDependency(BOOT_VERSION, "kafka"))
 			.hasDependency(getDependency(BOOT_VERSION, "kafka-streams"))
-			.hasDependency(RABBIT_BINDER)
+			.hasDependency(getDependency(BOOT_VERSION, "rabbitmq"))
 			.hasDependency(KAFKA_BINDER)
 			.hasDependency(KAFKA_STREAMS_BINDER)
+			.hasDependency(RABBIT_BINDER)
 			.hasDependency(Dependency.createSpringBootStarter("test", Dependency.SCOPE_TEST))
 			.hasDependency(TEST_BINDER)
 			.hasDependenciesSize(11);
 	}
 
 	@Test
-	void springCloudBusWithRabbit() {
-		ProjectRequest request = createProjectRequest(BOOT_VERSION, "cloud-bus", "amqp");
+	void springCloudBusWithRabbitMq() {
+		ProjectRequest request = createProjectRequest(BOOT_VERSION, "cloud-bus", "rabbitmq");
 		assertThat(mavenPom(request)).hasDependency(getDependency(BOOT_VERSION, "cloud-bus"))
-			.hasDependency(getDependency(BOOT_VERSION, "amqp"))
+			.hasDependency(getDependency(BOOT_VERSION, "rabbitmq"))
 			.hasDependency(RABBIT_BINDER)
 			.hasDependency(Dependency.createSpringBootStarter("test", Dependency.SCOPE_TEST))
 			.hasDependenciesSize(5);
@@ -119,23 +120,23 @@ class SpringCloudStreamBuildCustomizerTests extends AbstractExtensionTests {
 
 	@Test
 	void springCloudBusWithKafka() {
-		ProjectRequest request = createProjectRequest(BOOT_VERSION, "cloud-bus", "amqp");
+		ProjectRequest request = createProjectRequest(BOOT_VERSION, "cloud-bus", "kafka");
 		assertThat(mavenPom(request)).hasDependency(getDependency(BOOT_VERSION, "cloud-bus"))
-			.hasDependency(getDependency(BOOT_VERSION, "amqp"))
-			.hasDependency(RABBIT_BINDER)
+			.hasDependency(getDependency(BOOT_VERSION, "kafka"))
+			.hasDependency(KAFKA_BINDER)
 			.hasDependency(Dependency.createSpringBootStarter("test", Dependency.SCOPE_TEST))
 			.hasDependenciesSize(5);
 	}
 
 	@Test
 	void springCloudBusWithAllBinders() {
-		ProjectRequest request = createProjectRequest(BOOT_VERSION, "cloud-bus", "amqp", "kafka", "kafka-streams");
+		ProjectRequest request = createProjectRequest(BOOT_VERSION, "cloud-bus", "kafka", "kafka-streams", "rabbitmq");
 		assertThat(mavenPom(request)).hasDependency(getDependency(BOOT_VERSION, "cloud-bus"))
-			.hasDependency(getDependency(BOOT_VERSION, "amqp"))
 			.hasDependency(getDependency(BOOT_VERSION, "kafka"))
 			.hasDependency(getDependency(BOOT_VERSION, "kafka-streams"))
-			.hasDependency(RABBIT_BINDER)
+			.hasDependency(getDependency(BOOT_VERSION, "rabbitmq"))
 			.hasDependency(KAFKA_BINDER)
+			.hasDependency(RABBIT_BINDER)
 			.hasDependency(Dependency.createSpringBootStarter("test", Dependency.SCOPE_TEST))
 			.hasDependenciesSize(9);
 	}

--- a/start-site/src/test/java/io/spring/start/site/extension/dependency/springintegration/SpringIntegrationProjectGenerationConfigurationTests.java
+++ b/start-site/src/test/java/io/spring/start/site/extension/dependency/springintegration/SpringIntegrationProjectGenerationConfigurationTests.java
@@ -69,13 +69,13 @@ class SpringIntegrationProjectGenerationConfigurationTests extends AbstractExten
 	}
 
 	static Stream<Arguments> supportedEntries() {
-		return Stream.of(Arguments.arguments("artemis", "jms"), Arguments.arguments("amqp", "amqp"),
-				Arguments.arguments("amqp-streams", "amqp"), Arguments.arguments("data-jdbc", "jdbc"),
+		return Stream.of(Arguments.arguments("artemis", "jms"), Arguments.arguments("data-jdbc", "jdbc"),
 				Arguments.arguments("jdbc", "jdbc"), Arguments.arguments("data-jpa", "jpa"),
 				Arguments.arguments("data-mongodb", "mongodb"), Arguments.arguments("data-mongodb-reactive", "mongodb"),
 				Arguments.arguments("data-r2dbc", "r2dbc"), Arguments.arguments("data-redis", "redis"),
 				Arguments.arguments("data-redis-reactive", "redis"), Arguments.arguments("kafka", "kafka"),
 				Arguments.arguments("kafka-streams", "kafka"), Arguments.arguments("mail", "mail"),
+				Arguments.arguments("rabbitmq", "amqp"), Arguments.arguments("rabbitmq-streams", "amqp"),
 				Arguments.arguments("rsocket", "rsocket"), Arguments.arguments("web", "http"),
 				Arguments.arguments("webflux", "webflux"), Arguments.arguments("websocket", "websocket"),
 				Arguments.arguments("websocket", "stomp"), Arguments.arguments("web-services", "ws"));
@@ -96,13 +96,13 @@ class SpringIntegrationProjectGenerationConfigurationTests extends AbstractExten
 	}
 
 	static Stream<Arguments> referenceLinks() {
-		return Stream.of(Arguments.arguments("artemis", "jms"), Arguments.arguments("amqp", "amqp"),
-				Arguments.arguments("amqp-streams", "amqp"), Arguments.arguments("data-jdbc", "jdbc"),
+		return Stream.of(Arguments.arguments("artemis", "jms"), Arguments.arguments("data-jdbc", "jdbc"),
 				Arguments.arguments("jdbc", "jdbc"), Arguments.arguments("data-jpa", "jpa"),
 				Arguments.arguments("data-mongodb", "mongodb"), Arguments.arguments("data-mongodb-reactive", "mongodb"),
 				Arguments.arguments("data-r2dbc", "r2dbc"), Arguments.arguments("data-redis", "redis"),
 				Arguments.arguments("data-redis-reactive", "redis"), Arguments.arguments("kafka", "kafka"),
 				Arguments.arguments("kafka-streams", "kafka"), Arguments.arguments("mail", "mail"),
+				Arguments.arguments("rabbitmq", "amqp"), Arguments.arguments("rabbitmq-streams", "amqp"),
 				Arguments.arguments("rsocket", "rsocket"), Arguments.arguments("security", "security"),
 				Arguments.arguments("web", "http"), Arguments.arguments("webflux", "webflux"),
 				Arguments.arguments("websocket", "web-sockets"), Arguments.arguments("websocket", "stomp"),

--- a/start-site/src/test/java/io/spring/start/site/extension/dependency/springmodulith/SpringModulithBuildCustomizerTests.java
+++ b/start-site/src/test/java/io/spring/start/site/extension/dependency/springmodulith/SpringModulithBuildCustomizerTests.java
@@ -76,20 +76,27 @@ class SpringModulithBuildCustomizerTests extends AbstractExtensionTests {
 	}
 
 	@ParameterizedTest
-	@ValueSource(strings = { "amqp", "kafka" })
-	void addsExternalizationDependency(String broker) {
-		Build build = createBuild("modulith", broker);
-		this.customizer.customize(build);
-		assertThat(build.dependencies().ids()).contains("modulith-events-" + broker);
-		assertThat(build.dependencies().ids()).contains("modulith-events-api");
-	}
-
-	@ParameterizedTest
 	@ValueSource(strings = { "activemq", "artemis" })
 	void addsJmsExternalizationDependency(String broker) {
 		Build build = createBuild("modulith", broker);
 		this.customizer.customize(build);
 		assertThat(build.dependencies().ids()).contains("modulith-events-jms");
+		assertThat(build.dependencies().ids()).contains("modulith-events-api");
+	}
+
+	@Test
+	void addsKafkaExternalizationDependency() {
+		Build build = createBuild("modulith", "kafka");
+		this.customizer.customize(build);
+		assertThat(build.dependencies().ids()).contains("modulith-events-kafka");
+		assertThat(build.dependencies().ids()).contains("modulith-events-api");
+	}
+
+	@Test
+	void addsRabbitMqExternalizationDependency() {
+		Build build = createBuild("modulith", "rabbitmq");
+		this.customizer.customize(build);
+		assertThat(build.dependencies().ids()).contains("modulith-events-amqp");
 		assertThat(build.dependencies().ids()).contains("modulith-events-api");
 	}
 

--- a/start-site/src/test/java/io/spring/start/site/extension/dependency/testcontainers/TestcontainersProjectGenerationConfigurationTests.java
+++ b/start-site/src/test/java/io/spring/start/site/extension/dependency/testcontainers/TestcontainersProjectGenerationConfigurationTests.java
@@ -115,8 +115,8 @@ class TestcontainersProjectGenerationConfigurationTests extends AbstractExtensio
 	}
 
 	static Stream<Arguments> supportedEntriesHelpDocument() {
-		return Stream.of(Arguments.arguments("amqp", "https://java.testcontainers.org/modules/rabbitmq/"),
-				Arguments.arguments("amqp-streams", "https://java.testcontainers.org/modules/rabbitmq/"),
+		return Stream.of(Arguments.arguments("rabbitmq", "https://java.testcontainers.org/modules/rabbitmq/"),
+				Arguments.arguments("rabbitmq-streams", "https://java.testcontainers.org/modules/rabbitmq/"),
 				Arguments.arguments("cloud-gcp", "https://java.testcontainers.org/modules/gcloud/"),
 				Arguments.arguments("cloud-gcp-pubsub", "https://java.testcontainers.org/modules/gcloud/"),
 				Arguments.arguments("cloud-starter-consul-config", "https://java.testcontainers.org/modules/consul/"),


### PR DESCRIPTION
RabbitMQ support has moved from "amqp" to "rabbitmq" as of Spring Boot 4.1.0-M3. As a result, the coordinates have moved accordingly as of this version.

This is a breaking API change as the "amqp" dependency id no longer resolve.

See gh-2123

