### PR TITLE
Add infrastructure for Testcontainers generation code to add annotations

### DIFF
--- a/start-site/src/main/java/io/spring/start/site/container/ServiceConnections.java
+++ b/start-site/src/main/java/io/spring/start/site/container/ServiceConnections.java
@@ -49,6 +49,14 @@ public class ServiceConnections {
 		return this.connectionsById.values().stream().sorted(Comparator.comparing(ServiceConnection::id));
 	}
 
+	/**
+	 * A single additional annotation to emit on the generated container method, and an
+	 * optional callback to customize the {@link Annotation.Builder}.
+	 *
+	 * @param className the fully qualified annotation to add
+	 * @param customizer the attribute configuration, or {@code null} to apply no
+	 * attributes
+	 */
 	public record AnnotationRequest(ClassName className, Consumer<Annotation.Builder> customizer) {
 		public AnnotationRequest {
 			customizer = (customizer != null) ? customizer : (builder) -> {
@@ -56,6 +64,21 @@ public class ServiceConnections {
 		}
 	}
 
+	/**
+	 * A {@code @ServiceConnection} backed by a Testcontainers image and container class,
+	 * plus any extra method-level annotations to generate.
+	 *
+	 * @param id unique id for the connection
+	 * @param dockerService image, ports, and other compose metadata
+	 * @param containerClassName the container class to construct (or
+	 * {@link Testcontainers#GENERIC_CONTAINER_CLASS_NAME} for generic container support)
+	 * @param containerClassNameGeneric if the return type and constructor use a type
+	 * parameter
+	 * @param connectionName the value for the {@code name} attribute of
+	 * {@code @ServiceConnection} when not {@code null}
+	 * @param annotations additional annotations to place on the generated method after
+	 * {@code @Bean} and {@code @ServiceConnection}
+	 */
 	public record ServiceConnection(String id, DockerService dockerService, String containerClassName,
 			boolean containerClassNameGeneric, String connectionName, List<AnnotationRequest> annotations) {
 
@@ -63,33 +86,74 @@ public class ServiceConnections {
 			annotations = (annotations != null) ? List.copyOf(annotations) : List.of();
 		}
 
-		public static ServiceConnection ofGenericContainer(String id, DockerService dockerService,
-				String connectionName) {
-			return new ServiceConnection(id, dockerService, Testcontainers.GENERIC_CONTAINER_CLASS_NAME, true,
-					connectionName, List.of());
-		}
-
-		public static ServiceConnection ofContainer(String id, DockerService dockerService, String containerClassName,
-				boolean containerClassNameGeneric) {
-			return new ServiceConnection(id, dockerService, containerClassName, containerClassNameGeneric, null,
-					List.of());
-		}
-
+		/**
+		 * Whether this connection uses
+		 * {@value Testcontainers#GENERIC_CONTAINER_CLASS_NAME} (see
+		 * {@link Testcontainers}) rather than a specific container class.
+		 * @return {@code true} for generic container usage
+		 */
 		public boolean isGenericContainer() {
 			return this.containerClassName.equals(Testcontainers.GENERIC_CONTAINER_CLASS_NAME);
 		}
 
+		/**
+		 * Add an annotation on the generated container method, with no attributes.
+		 * Returns a new instance; this record is not modified.
+		 * @param annotationClassName the annotation to add
+		 * @return a new {@link ServiceConnection} with the additional annotation
+		 * @see #withAnnotation(ClassName, Consumer)
+		 */
 		public ServiceConnection withAnnotation(ClassName annotationClassName) {
 			return withAnnotation(annotationClassName, (builder) -> {
 			});
 		}
 
+		/**
+		 * Add an annotation on the generated container method, configuring attributes on
+		 * {@link Annotation.Builder}. Returns a new instance; this record is not
+		 * modified.
+		 * @param annotationClassName the annotation to add
+		 * @param customizer attribute configuration, or {@code null} to apply no
+		 * attributes
+		 * @return a new {@link ServiceConnection} with the additional annotation
+		 */
 		public ServiceConnection withAnnotation(ClassName annotationClassName,
 				Consumer<Annotation.Builder> customizer) {
 			List<AnnotationRequest> newAnnotations = new ArrayList<>(this.annotations);
 			newAnnotations.add(new AnnotationRequest(annotationClassName, customizer));
 			return new ServiceConnection(this.id, this.dockerService, this.containerClassName,
 					this.containerClassNameGeneric, this.connectionName, newAnnotations);
+		}
+
+		/**
+		 * Create a service connection for a generic Testcontainers container (see
+		 * {@value Testcontainers#GENERIC_CONTAINER_CLASS_NAME}) and set the
+		 * {@code @ServiceConnection#name} attribute to {@code connectionName}.
+		 * @param id unique id for the connection
+		 * @param dockerService image, ports, and other compose metadata
+		 * @param connectionName the {@code name} for {@code @ServiceConnection}
+		 * @return a new {@link ServiceConnection}
+		 */
+		public static ServiceConnection ofGenericContainer(String id, DockerService dockerService,
+				String connectionName) {
+			return new ServiceConnection(id, dockerService, Testcontainers.GENERIC_CONTAINER_CLASS_NAME, true,
+					connectionName, List.of());
+		}
+
+		/**
+		 * Create a service connection for a typed Testcontainers class (no
+		 * {@code @ServiceConnection#name} attribute).
+		 * @param id unique id for the connection
+		 * @param dockerService image, ports, and other compose metadata
+		 * @param containerClassName the container class to construct
+		 * @param containerClassNameGeneric if the return type and constructor use a type
+		 * parameter
+		 * @return a new {@link ServiceConnection}
+		 */
+		public static ServiceConnection ofContainer(String id, DockerService dockerService, String containerClassName,
+				boolean containerClassNameGeneric) {
+			return new ServiceConnection(id, dockerService, containerClassName, containerClassNameGeneric, null,
+					List.of());
 		}
 	}
 

--- a/start-site/src/main/java/io/spring/start/site/container/ServiceConnections.java
+++ b/start-site/src/main/java/io/spring/start/site/container/ServiceConnections.java
@@ -16,15 +16,22 @@
 
 package io.spring.start.site.container;
 
+import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.function.Consumer;
 import java.util.stream.Stream;
+
+import io.spring.initializr.generator.language.Annotation;
+import io.spring.initializr.generator.language.ClassName;
 
 /**
  * Container for {@link ServiceConnection}.
  *
  * @author Stephane Nicoll
+ * @author Kaique Vieira Soares
  */
 public class ServiceConnections {
 
@@ -42,24 +49,48 @@ public class ServiceConnections {
 		return this.connectionsById.values().stream().sorted(Comparator.comparing(ServiceConnection::id));
 	}
 
+	public record AnnotationRequest(ClassName className, Consumer<Annotation.Builder> customizer) {
+		public AnnotationRequest {
+			customizer = (customizer != null) ? customizer : (builder) -> {
+			};
+		}
+	}
+
 	public record ServiceConnection(String id, DockerService dockerService, String containerClassName,
-			boolean containerClassNameGeneric, String connectionName) {
+			boolean containerClassNameGeneric, String connectionName, List<AnnotationRequest> annotations) {
+
+		public ServiceConnection {
+			annotations = (annotations != null) ? List.copyOf(annotations) : List.of();
+		}
 
 		public static ServiceConnection ofGenericContainer(String id, DockerService dockerService,
 				String connectionName) {
 			return new ServiceConnection(id, dockerService, Testcontainers.GENERIC_CONTAINER_CLASS_NAME, true,
-					connectionName);
+					connectionName, List.of());
 		}
 
 		public static ServiceConnection ofContainer(String id, DockerService dockerService, String containerClassName,
 				boolean containerClassNameGeneric) {
-			return new ServiceConnection(id, dockerService, containerClassName, containerClassNameGeneric, null);
+			return new ServiceConnection(id, dockerService, containerClassName, containerClassNameGeneric, null,
+					List.of());
 		}
 
 		public boolean isGenericContainer() {
 			return this.containerClassName.equals(Testcontainers.GENERIC_CONTAINER_CLASS_NAME);
 		}
 
+		public ServiceConnection withAnnotation(ClassName annotationClassName) {
+			return withAnnotation(annotationClassName, (builder) -> {
+			});
+		}
+
+		public ServiceConnection withAnnotation(ClassName annotationClassName,
+				Consumer<Annotation.Builder> customizer) {
+			List<AnnotationRequest> newAnnotations = new ArrayList<>(this.annotations);
+			newAnnotations.add(new AnnotationRequest(annotationClassName, customizer));
+			return new ServiceConnection(this.id, this.dockerService, this.containerClassName,
+					this.containerClassNameGeneric, this.connectionName, newAnnotations);
+		}
 	}
 
 }

--- a/start-site/src/main/java/io/spring/start/site/extension/dependency/testcontainers/GroovyTestContainersApplicationCodeProjectContributor.java
+++ b/start-site/src/main/java/io/spring/start/site/extension/dependency/testcontainers/GroovyTestContainersApplicationCodeProjectContributor.java
@@ -42,6 +42,7 @@ import org.springframework.boot.SpringApplication;
  * {@link TestContainersApplicationCodeProjectContributor} implementation for Groovy.
  *
  * @author Stephane Nicoll
+ * @author Kaique Vieira Soares
  */
 class GroovyTestContainersApplicationCodeProjectContributor extends
 		TestContainersApplicationCodeProjectContributor<GroovyTypeDeclaration, GroovyCompilationUnit, GroovySourceCode> {
@@ -73,18 +74,17 @@ class GroovyTestContainersApplicationCodeProjectContributor extends
 		DockerService dockerService = serviceConnection.dockerService();
 		String imageId = "%s:%s".formatted(dockerService.getImage(), dockerService.getImageTag());
 		if (serviceConnection.isGenericContainer()) {
-			typeDeclaration.addMethodDeclaration(usingGenericContainer(methodName, imageId,
-					serviceConnection.connectionName(), dockerService.getPorts()));
+			typeDeclaration.addMethodDeclaration(
+					usingGenericContainer(methodName, imageId, serviceConnection, dockerService.getPorts()));
 		}
 		else {
-			typeDeclaration.addMethodDeclaration(usingSpecificContainer(methodName, imageId,
-					serviceConnection.containerClassName(), serviceConnection.containerClassNameGeneric()));
+			typeDeclaration.addMethodDeclaration(usingSpecificContainer(methodName, imageId, serviceConnection));
 		}
 
 	}
 
-	private GroovyMethodDeclaration usingGenericContainer(String methodName, String imageId, String connectionName,
-			Set<PortMapping> ports) {
+	private GroovyMethodDeclaration usingGenericContainer(String methodName, String imageId,
+			ServiceConnection serviceConnection, Set<PortMapping> ports) {
 		String portsParameter = ports.stream()
 			.map((port) -> String.valueOf(port.getContainerPort()))
 			.collect(Collectors.joining(", "));
@@ -93,17 +93,18 @@ class GroovyTestContainersApplicationCodeProjectContributor extends
 			.body(CodeBlock.ofStatement("new $T<>($L).withExposedPorts($L)",
 					Testcontainers.GENERIC_CONTAINER_CLASS_NAME, generatedDockerImageNameCode(imageId),
 					portsParameter));
-		annotateContainerMethod(method, connectionName);
+		annotateContainerMethod(method, serviceConnection);
 		return method;
 	}
 
-	private GroovyMethodDeclaration usingSpecificContainer(String methodName, String imageId, String containerClassName,
-			boolean containerClassNameGeneric) {
-		String statementFormat = containerClassNameGeneric ? "new $T<>($L)" : "new $T($L)";
+	private GroovyMethodDeclaration usingSpecificContainer(String methodName, String imageId,
+			ServiceConnection serviceConnection) {
+		String statementFormat = serviceConnection.containerClassNameGeneric() ? "new $T<>($L)" : "new $T($L)";
 		GroovyMethodDeclaration method = GroovyMethodDeclaration.method(methodName)
-			.returning(containerClassName)
-			.body(CodeBlock.ofStatement(statementFormat, containerClassName, generatedDockerImageNameCode(imageId)));
-		annotateContainerMethod(method, null);
+			.returning(serviceConnection.containerClassName())
+			.body(CodeBlock.ofStatement(statementFormat, serviceConnection.containerClassName(),
+					generatedDockerImageNameCode(imageId)));
+		annotateContainerMethod(method, serviceConnection);
 		return method;
 	}
 

--- a/start-site/src/main/java/io/spring/start/site/extension/dependency/testcontainers/JavaTestContainersApplicationCodeProjectContributor.java
+++ b/start-site/src/main/java/io/spring/start/site/extension/dependency/testcontainers/JavaTestContainersApplicationCodeProjectContributor.java
@@ -43,6 +43,7 @@ import org.springframework.util.ClassUtils;
  * {@link TestContainersApplicationCodeProjectContributor} implementation for Java.
  *
  * @author Stephane Nicoll
+ * @author Kaique Vieira Soares
  */
 class JavaTestContainersApplicationCodeProjectContributor extends
 		TestContainersApplicationCodeProjectContributor<JavaTypeDeclaration, JavaCompilationUnit, JavaSourceCode> {
@@ -73,17 +74,16 @@ class JavaTestContainersApplicationCodeProjectContributor extends
 		DockerService dockerService = serviceConnection.dockerService();
 		String imageId = "%s:%s".formatted(dockerService.getImage(), dockerService.getImageTag());
 		if (serviceConnection.isGenericContainer()) {
-			typeDeclaration.addMethodDeclaration(usingGenericContainer(methodName, imageId,
-					serviceConnection.connectionName(), dockerService.getPorts()));
+			typeDeclaration.addMethodDeclaration(
+					usingGenericContainer(methodName, imageId, serviceConnection, dockerService.getPorts()));
 		}
 		else {
-			typeDeclaration.addMethodDeclaration(usingSpecificContainer(methodName, imageId,
-					serviceConnection.containerClassName(), serviceConnection.containerClassNameGeneric()));
+			typeDeclaration.addMethodDeclaration(usingSpecificContainer(methodName, imageId, serviceConnection));
 		}
 	}
 
-	private JavaMethodDeclaration usingGenericContainer(String methodName, String imageId, String connectionName,
-			Set<PortMapping> ports) {
+	private JavaMethodDeclaration usingGenericContainer(String methodName, String imageId,
+			ServiceConnection serviceConnection, Set<PortMapping> ports) {
 		String portsParameter = ports.stream()
 			.map((port) -> String.valueOf(port.getContainerPort()))
 			.collect(Collectors.joining(", "));
@@ -92,19 +92,24 @@ class JavaTestContainersApplicationCodeProjectContributor extends
 			.body(CodeBlock.ofStatement("return new $T<>($L).withExposedPorts($L)",
 					Testcontainers.GENERIC_CONTAINER_CLASS_NAME, generatedDockerImageNameCode(imageId),
 					portsParameter));
-		annotateContainerMethod(method, connectionName);
+
+		annotateContainerMethod(method, serviceConnection);
 		return method;
 	}
 
-	private JavaMethodDeclaration usingSpecificContainer(String methodName, String imageId, String containerClassName,
-			boolean containerClassNameGeneric) {
+	private JavaMethodDeclaration usingSpecificContainer(String methodName, String imageId,
+			ServiceConnection serviceConnection) {
+		String containerClassName = serviceConnection.containerClassName();
+		boolean containerClassNameGeneric = serviceConnection.containerClassNameGeneric();
+
 		String returnType = (containerClassNameGeneric) ? ClassUtils.getShortName(containerClassName) + "<?>"
 				: containerClassName;
 		String statementFormat = (containerClassNameGeneric) ? "return new $T<>($L)" : "return new $T($L)";
 		JavaMethodDeclaration method = JavaMethodDeclaration.method(methodName)
 			.returning(returnType)
 			.body(CodeBlock.ofStatement(statementFormat, containerClassName, generatedDockerImageNameCode(imageId)));
-		annotateContainerMethod(method, null);
+
+		annotateContainerMethod(method, serviceConnection);
 		return method;
 	}
 

--- a/start-site/src/main/java/io/spring/start/site/extension/dependency/testcontainers/KotlinTestContainersApplicationCodeProjectContributor.java
+++ b/start-site/src/main/java/io/spring/start/site/extension/dependency/testcontainers/KotlinTestContainersApplicationCodeProjectContributor.java
@@ -41,6 +41,7 @@ import org.springframework.util.ClassUtils;
  * {@link TestContainersApplicationCodeProjectContributor} implementation for Kotlin.
  *
  * @author Stephane Nicoll
+ * @author Kaique Vieira Soares
  */
 class KotlinTestContainersApplicationCodeProjectContributor extends
 		TestContainersApplicationCodeProjectContributor<KotlinTypeDeclaration, KotlinCompilationUnit, KotlinSourceCode> {
@@ -69,17 +70,16 @@ class KotlinTestContainersApplicationCodeProjectContributor extends
 		DockerService dockerService = serviceConnection.dockerService();
 		String imageId = "%s:%s".formatted(dockerService.getImage(), dockerService.getImageTag());
 		if (serviceConnection.isGenericContainer()) {
-			typeDeclaration.addFunctionDeclaration(usingGenericContainer(methodName, imageId,
-					serviceConnection.connectionName(), dockerService.getPorts()));
+			typeDeclaration.addFunctionDeclaration(
+					usingGenericContainer(methodName, imageId, serviceConnection, dockerService.getPorts()));
 		}
 		else {
-			typeDeclaration.addFunctionDeclaration(usingSpecificContainer(methodName, imageId,
-					serviceConnection.containerClassName(), serviceConnection.containerClassNameGeneric()));
+			typeDeclaration.addFunctionDeclaration(usingSpecificContainer(methodName, imageId, serviceConnection));
 		}
 	}
 
-	private KotlinFunctionDeclaration usingGenericContainer(String functionName, String imageId, String connectionName,
-			Set<PortMapping> ports) {
+	private KotlinFunctionDeclaration usingGenericContainer(String functionName, String imageId,
+			ServiceConnection serviceConnection, Set<PortMapping> ports) {
 		String portsParameter = ports.stream()
 			.map((port) -> String.valueOf(port.getContainerPort()))
 			.collect(Collectors.joining(", "));
@@ -88,18 +88,20 @@ class KotlinTestContainersApplicationCodeProjectContributor extends
 			.body(CodeBlock.ofStatement("return $T($L).withExposedPorts($L)",
 					Testcontainers.GENERIC_CONTAINER_CLASS_NAME, generatedDockerImageNameCode(imageId),
 					portsParameter));
-		annotateContainerMethod(method, connectionName);
+		annotateContainerMethod(method, serviceConnection);
 		return method;
 	}
 
 	private KotlinFunctionDeclaration usingSpecificContainer(String functionName, String imageId,
-			String containerClassName, boolean containerClassNameGeneric) {
-		String returnType = (containerClassNameGeneric) ? ClassUtils.getShortName(containerClassName) + "<*>"
-				: containerClassName;
+			ServiceConnection serviceConnection) {
+		String returnType = (serviceConnection.containerClassNameGeneric())
+				? ClassUtils.getShortName(serviceConnection.containerClassName()) + "<*>"
+				: serviceConnection.containerClassName();
 		KotlinFunctionDeclaration method = KotlinFunctionDeclaration.function(functionName)
 			.returning(returnType)
-			.body(CodeBlock.ofStatement("return $T($L)", containerClassName, generatedDockerImageNameCode(imageId)));
-		annotateContainerMethod(method, null);
+			.body(CodeBlock.ofStatement("return $T($L)", serviceConnection.containerClassName(),
+					generatedDockerImageNameCode(imageId)));
+		annotateContainerMethod(method, serviceConnection);
 		return method;
 	}
 

--- a/start-site/src/main/java/io/spring/start/site/extension/dependency/testcontainers/TestContainersApplicationCodeProjectContributor.java
+++ b/start-site/src/main/java/io/spring/start/site/extension/dependency/testcontainers/TestContainersApplicationCodeProjectContributor.java
@@ -41,6 +41,7 @@ import io.spring.start.site.container.ServiceConnections.ServiceConnection;
  * @param <S> language-specific source code
  * @author Stephane Nicoll
  * @author Moritz Halbritter
+ * @author Kaique Vieira Soares
  */
 abstract class TestContainersApplicationCodeProjectContributor<T extends TypeDeclaration, C extends CompilationUnit<T>, S extends SourceCode<T, C>>
 		implements ProjectContributor {
@@ -121,13 +122,17 @@ abstract class TestContainersApplicationCodeProjectContributor<T extends TypeDec
 		});
 	}
 
-	protected void annotateContainerMethod(Annotatable annotable, String name) {
+	protected void annotateContainerMethod(Annotatable annotable, ServiceConnection serviceConnection) {
 		annotable.annotations().addSingle(BEAN_CLASS_NAME);
 		annotable.annotations().addSingle(SERVICE_CONNECTION_CLASS_NAME, (annotation) -> {
-			if (name != null) {
-				annotation.set("name", name);
+			if (serviceConnection.connectionName() != null) {
+				annotation.set("name", serviceConnection.connectionName());
 			}
 		});
+
+		for (ServiceConnections.AnnotationRequest request : serviceConnection.annotations()) {
+			annotable.annotations().addSingle(request.className(), request.customizer());
+		}
 	}
 
 	private String getTestApplicationName() {

--- a/start-site/src/main/java/io/spring/start/site/extension/dependency/testcontainers/TestContainersApplicationCodeProjectContributor.java
+++ b/start-site/src/main/java/io/spring/start/site/extension/dependency/testcontainers/TestContainersApplicationCodeProjectContributor.java
@@ -129,7 +129,6 @@ abstract class TestContainersApplicationCodeProjectContributor<T extends TypeDec
 				annotation.set("name", serviceConnection.connectionName());
 			}
 		});
-
 		for (ServiceConnections.AnnotationRequest request : serviceConnection.annotations()) {
 			annotable.annotations().addSingle(request.className(), request.customizer());
 		}

--- a/start-site/src/test/java/io/spring/start/site/container/ServiceConnectionsTests.java
+++ b/start-site/src/test/java/io/spring/start/site/container/ServiceConnectionsTests.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2012 - present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.spring.start.site.container;
+
+import io.spring.initializr.generator.language.ClassName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+
+/**
+ * Tests for {@link ServiceConnections}.
+ *
+ * @author Kaique Vieira Soares
+ */
+class ServiceConnectionsTests {
+
+	@Test
+	void addServiceConnectionStoresAndSortsById() {
+		ServiceConnections connections = new ServiceConnections();
+		ServiceConnections.ServiceConnection conn1 = ServiceConnections.ServiceConnection.ofContainer("zeta", null,
+				"com.example.Zeta", false);
+		ServiceConnections.ServiceConnection conn2 = ServiceConnections.ServiceConnection.ofContainer("alpha", null,
+				"com.example.Alpha", false);
+
+		connections.addServiceConnection(conn1);
+		connections.addServiceConnection(conn2);
+
+		assertThat(connections.values()).containsExactly(conn2, conn1);
+	}
+
+	@Test
+	void addServiceConnectionWithDuplicateIdThrowsException() {
+		ServiceConnections connections = new ServiceConnections();
+		ServiceConnections.ServiceConnection conn = ServiceConnections.ServiceConnection.ofContainer("test", null,
+				"com.example.Test", false);
+
+		connections.addServiceConnection(conn);
+
+		assertThatIllegalArgumentException().isThrownBy(() -> connections.addServiceConnection(conn))
+			.withMessageContaining("Connection with id 'test' already registered");
+	}
+
+	@Test
+	void annotationRequestHandlesNullAttributes() {
+		ServiceConnections.AnnotationRequest request = new ServiceConnections.AnnotationRequest(
+				ClassName.of("org.example.Test"), null);
+		assertThat(request.customizer()).isNotNull();
+	}
+
+	@Test
+	void serviceConnectionHandlesNullAnnotations() {
+		ServiceConnections.ServiceConnection conn = new ServiceConnections.ServiceConnection("test", null,
+				"com.example.Test", false, null, null);
+		assertThat(conn.annotations()).isEmpty();
+	}
+
+	@Test
+	void ofGenericContainerCreatesExpectedInstance() {
+		ServiceConnections.ServiceConnection conn = ServiceConnections.ServiceConnection.ofGenericContainer("redis",
+				null, "redisConnection");
+
+		assertThat(conn.id()).isEqualTo("redis");
+		assertThat(conn.isGenericContainer()).isTrue();
+		assertThat(conn.connectionName()).isEqualTo("redisConnection");
+		assertThat(conn.annotations()).isEmpty();
+	}
+
+	@Test
+	void ofContainerCreatesExpectedInstance() {
+		ServiceConnections.ServiceConnection conn = ServiceConnections.ServiceConnection.ofContainer("mongo", null,
+				"org.testcontainers.containers.MongoDBContainer", false);
+
+		assertThat(conn.id()).isEqualTo("mongo");
+		assertThat(conn.isGenericContainer()).isFalse();
+		assertThat(conn.connectionName()).isNull();
+		assertThat(conn.annotations()).isEmpty();
+	}
+
+	@Test
+	void withAnnotationAddsSimpleAnnotationAndPreservesImmutability() {
+		ServiceConnections.ServiceConnection original = ServiceConnections.ServiceConnection.ofContainer("test", null,
+				"com.example.Test", false);
+
+		ServiceConnections.ServiceConnection updated = original.withAnnotation(ClassName.of("org.example.Ssl"));
+
+		assertThat(original.annotations()).isEmpty();
+		assertThat(updated.annotations()).hasSize(1)
+			.extracting(ServiceConnections.AnnotationRequest::className)
+			.containsExactly(ClassName.of("org.example.Ssl"));
+	}
+
+	@Test
+	void withAnnotationAddsAnnotationWithCustomizer() {
+		ServiceConnections.ServiceConnection original = ServiceConnections.ServiceConnection.ofContainer("test", null,
+				"com.example.Test", false);
+
+		ServiceConnections.ServiceConnection updated = original.withAnnotation(ClassName.of("org.example.Ssl"),
+				(builder) -> {
+					builder.set("bundle", "mybundle");
+					builder.set("enabled", true);
+				});
+
+		assertThat(updated.annotations()).hasSize(1)
+			.extracting(ServiceConnections.AnnotationRequest::className)
+			.containsExactly(ClassName.of("org.example.Ssl"));
+	}
+
+	@Test
+	void withAnnotationChainingAddsMultipleAnnotations() {
+		ServiceConnections.ServiceConnection conn = ServiceConnections.ServiceConnection
+			.ofContainer("test", null, "com.example.Test", false)
+			.withAnnotation(ClassName.of("org.example.First"))
+			.withAnnotation(ClassName.of("org.example.Second"), (builder) -> builder.set("priority", 1));
+
+		assertThat(conn.annotations()).hasSize(2)
+			.extracting(ServiceConnections.AnnotationRequest::className)
+			.containsExactly(ClassName.of("org.example.First"), ClassName.of("org.example.Second"));
+	}
+
+}

--- a/start-site/src/test/java/io/spring/start/site/container/ServiceConnectionsTests.java
+++ b/start-site/src/test/java/io/spring/start/site/container/ServiceConnectionsTests.java
@@ -16,11 +16,13 @@
 
 package io.spring.start.site.container;
 
+import io.spring.initializr.generator.language.Annotation;
 import io.spring.initializr.generator.language.ClassName;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.assertj.core.api.Assertions.tuple;
 
 /**
  * Tests for {@link ServiceConnections}.
@@ -36,10 +38,8 @@ class ServiceConnectionsTests {
 				"com.example.Zeta", false);
 		ServiceConnections.ServiceConnection conn2 = ServiceConnections.ServiceConnection.ofContainer("alpha", null,
 				"com.example.Alpha", false);
-
 		connections.addServiceConnection(conn1);
 		connections.addServiceConnection(conn2);
-
 		assertThat(connections.values()).containsExactly(conn2, conn1);
 	}
 
@@ -48,18 +48,19 @@ class ServiceConnectionsTests {
 		ServiceConnections connections = new ServiceConnections();
 		ServiceConnections.ServiceConnection conn = ServiceConnections.ServiceConnection.ofContainer("test", null,
 				"com.example.Test", false);
-
 		connections.addServiceConnection(conn);
-
 		assertThatIllegalArgumentException().isThrownBy(() -> connections.addServiceConnection(conn))
 			.withMessageContaining("Connection with id 'test' already registered");
 	}
 
 	@Test
-	void annotationRequestHandlesNullAttributes() {
+	void annotationRequestHandlesNullCustomizer() {
 		ServiceConnections.AnnotationRequest request = new ServiceConnections.AnnotationRequest(
 				ClassName.of("org.example.Test"), null);
 		assertThat(request.customizer()).isNotNull();
+		Annotation built = buildAnnotationWithCustomizer(request);
+		assertThat(built.getClassName()).isEqualTo(request.className());
+		assertThat(built.getAttributes()).isEmpty();
 	}
 
 	@Test
@@ -73,7 +74,6 @@ class ServiceConnectionsTests {
 	void ofGenericContainerCreatesExpectedInstance() {
 		ServiceConnections.ServiceConnection conn = ServiceConnections.ServiceConnection.ofGenericContainer("redis",
 				null, "redisConnection");
-
 		assertThat(conn.id()).isEqualTo("redis");
 		assertThat(conn.isGenericContainer()).isTrue();
 		assertThat(conn.connectionName()).isEqualTo("redisConnection");
@@ -84,7 +84,6 @@ class ServiceConnectionsTests {
 	void ofContainerCreatesExpectedInstance() {
 		ServiceConnections.ServiceConnection conn = ServiceConnections.ServiceConnection.ofContainer("mongo", null,
 				"org.testcontainers.containers.MongoDBContainer", false);
-
 		assertThat(conn.id()).isEqualTo("mongo");
 		assertThat(conn.isGenericContainer()).isFalse();
 		assertThat(conn.connectionName()).isNull();
@@ -95,9 +94,7 @@ class ServiceConnectionsTests {
 	void withAnnotationAddsSimpleAnnotationAndPreservesImmutability() {
 		ServiceConnections.ServiceConnection original = ServiceConnections.ServiceConnection.ofContainer("test", null,
 				"com.example.Test", false);
-
 		ServiceConnections.ServiceConnection updated = original.withAnnotation(ClassName.of("org.example.Ssl"));
-
 		assertThat(original.annotations()).isEmpty();
 		assertThat(updated.annotations()).hasSize(1)
 			.extracting(ServiceConnections.AnnotationRequest::className)
@@ -106,30 +103,44 @@ class ServiceConnectionsTests {
 
 	@Test
 	void withAnnotationAddsAnnotationWithCustomizer() {
+		ClassName ssl = ClassName.of("org.example.Ssl");
 		ServiceConnections.ServiceConnection original = ServiceConnections.ServiceConnection.ofContainer("test", null,
 				"com.example.Test", false);
-
-		ServiceConnections.ServiceConnection updated = original.withAnnotation(ClassName.of("org.example.Ssl"),
-				(builder) -> {
-					builder.set("bundle", "mybundle");
-					builder.set("enabled", true);
-				});
-
-		assertThat(updated.annotations()).hasSize(1)
-			.extracting(ServiceConnections.AnnotationRequest::className)
-			.containsExactly(ClassName.of("org.example.Ssl"));
+		ServiceConnections.ServiceConnection updated = original.withAnnotation(ssl, (builder) -> {
+			builder.set("bundle", "mybundle");
+			builder.set("enabled", true);
+		});
+		assertThat(updated.annotations()).hasSize(1);
+		ServiceConnections.AnnotationRequest request = updated.annotations().get(0);
+		assertThat(request.className()).isEqualTo(ssl);
+		Annotation built = buildAnnotationWithCustomizer(request);
+		assertThat(built.getAttributes()).extracting(Annotation.Attribute::getName, (attr) -> attr.getValues().get(0))
+			.containsExactlyInAnyOrder(tuple("bundle", "mybundle"), tuple("enabled", true));
 	}
 
 	@Test
 	void withAnnotationChainingAddsMultipleAnnotations() {
+		ClassName first = ClassName.of("org.example.First");
+		ClassName second = ClassName.of("org.example.Second");
 		ServiceConnections.ServiceConnection conn = ServiceConnections.ServiceConnection
 			.ofContainer("test", null, "com.example.Test", false)
-			.withAnnotation(ClassName.of("org.example.First"))
-			.withAnnotation(ClassName.of("org.example.Second"), (builder) -> builder.set("priority", 1));
-
+			.withAnnotation(first)
+			.withAnnotation(second, (builder) -> builder.set("priority", 1));
 		assertThat(conn.annotations()).hasSize(2)
 			.extracting(ServiceConnections.AnnotationRequest::className)
-			.containsExactly(ClassName.of("org.example.First"), ClassName.of("org.example.Second"));
+			.containsExactly(first, second);
+		assertThat(buildAnnotationWithCustomizer(conn.annotations().get(0)).getAttributes()).isEmpty();
+		Annotation secondBuilt = buildAnnotationWithCustomizer(conn.annotations().get(1));
+		assertThat(secondBuilt.getClassName()).isEqualTo(second);
+		assertThat(secondBuilt.getAttributes())
+			.extracting(Annotation.Attribute::getName, (attr) -> attr.getValues().get(0))
+			.containsExactly(tuple("priority", 1));
+	}
+
+	private static Annotation buildAnnotationWithCustomizer(ServiceConnections.AnnotationRequest request) {
+		Annotation.Builder builder = Annotation.of(request.className());
+		request.customizer().accept(builder);
+		return builder.build();
 	}
 
 }

--- a/start-site/src/test/java/io/spring/start/site/extension/dependency/testcontainers/TestcontainersInfrastructureIntegrationTests.java
+++ b/start-site/src/test/java/io/spring/start/site/extension/dependency/testcontainers/TestcontainersInfrastructureIntegrationTests.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2012 - present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.spring.start.site.extension.dependency.testcontainers;
+
+import io.spring.initializr.generator.language.ClassName;
+import io.spring.initializr.generator.test.project.ProjectStructure;
+import io.spring.initializr.web.project.ProjectRequest;
+import io.spring.start.site.container.DockerService;
+import io.spring.start.site.container.ServiceConnections.ServiceConnection;
+import io.spring.start.site.container.ServiceConnectionsCustomizer;
+import io.spring.start.site.extension.AbstractExtensionTests;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Integration tests for the Testcontainers annotation infrastructure. Ensures that the
+ * generator can render annotations independently of specific modules.
+ *
+ * @author Kaique Vieira Soares
+ */
+@Import(TestcontainersInfrastructureIntegrationTests.InfrastructureTestConfiguration.class)
+class TestcontainersInfrastructureIntegrationTests extends AbstractExtensionTests {
+
+	@Test
+	void rendersCustomAnnotationsWithAndWithoutParametersInJava() {
+		ProjectRequest request = createProjectRequest("testcontainers");
+		request.setLanguage("java");
+		ProjectStructure project = generateProject(request);
+
+		assertThat(project).textFile("src/test/java/com/example/demo/TestcontainersConfiguration.java")
+			.contains("import com.example.SimpleAnno;")
+			.contains("import com.example.ParamAnno;")
+			.contains("@SimpleAnno")
+			.contains("@ParamAnno(stringValue = \"value\", booleanValue = true, intValue = 42)");
+	}
+
+	@Test
+	void rendersCustomAnnotationsWithAndWithoutParametersInKotlin() {
+		ProjectRequest request = createProjectRequest("testcontainers");
+		request.setLanguage("kotlin");
+		ProjectStructure project = generateProject(request);
+
+		assertThat(project).textFile("src/test/kotlin/com/example/demo/TestcontainersConfiguration.kt")
+			.contains("import com.example.SimpleAnno")
+			.contains("import com.example.ParamAnno")
+			.contains("@SimpleAnno")
+			.contains("@ParamAnno(stringValue = \"value\", booleanValue = true, intValue = 42)");
+	}
+
+	@Test
+	void rendersCustomAnnotationsWithAndWithoutParametersInGroovy() {
+		ProjectRequest request = createProjectRequest("testcontainers");
+		request.setLanguage("groovy");
+		ProjectStructure project = generateProject(request);
+
+		assertThat(project).textFile("src/test/groovy/com/example/demo/TestcontainersConfiguration.groovy")
+			.contains("import com.example.SimpleAnno")
+			.contains("import com.example.ParamAnno")
+			.contains("@SimpleAnno")
+			.contains("@ParamAnno(stringValue = \"value\", booleanValue = true, intValue = 42)");
+	}
+
+	@TestConfiguration
+	static class InfrastructureTestConfiguration {
+
+		@Bean
+		ServiceConnectionsCustomizer fakeInfrastructureCustomizer() {
+			return (serviceConnections) -> {
+
+				DockerService fakeDockerService = DockerService.withImageAndTag("fake-image:latest")
+					.website("https://example.com")
+					.build();
+
+				ServiceConnection connection = ServiceConnection
+					.ofContainer("fake", fakeDockerService, "com.example.FakeContainer", false)
+					.withAnnotation(ClassName.of("com.example.SimpleAnno"))
+					.withAnnotation(ClassName.of("com.example.ParamAnno"), (annotation) -> {
+						annotation.set("stringValue", "value");
+						annotation.set("booleanValue", true);
+						annotation.set("intValue", 42);
+					});
+
+				serviceConnections.addServiceConnection(connection);
+			};
+		}
+
+	}
+
+}

--- a/start-site/src/test/java/io/spring/start/site/extension/dependency/testcontainers/TestcontainersInfrastructureIntegrationTests.java
+++ b/start-site/src/test/java/io/spring/start/site/extension/dependency/testcontainers/TestcontainersInfrastructureIntegrationTests.java
@@ -45,7 +45,6 @@ class TestcontainersInfrastructureIntegrationTests extends AbstractExtensionTest
 		ProjectRequest request = createProjectRequest("testcontainers");
 		request.setLanguage("java");
 		ProjectStructure project = generateProject(request);
-
 		assertThat(project).textFile("src/test/java/com/example/demo/TestcontainersConfiguration.java")
 			.contains("import com.example.SimpleAnno;")
 			.contains("import com.example.ParamAnno;")
@@ -58,7 +57,6 @@ class TestcontainersInfrastructureIntegrationTests extends AbstractExtensionTest
 		ProjectRequest request = createProjectRequest("testcontainers");
 		request.setLanguage("kotlin");
 		ProjectStructure project = generateProject(request);
-
 		assertThat(project).textFile("src/test/kotlin/com/example/demo/TestcontainersConfiguration.kt")
 			.contains("import com.example.SimpleAnno")
 			.contains("import com.example.ParamAnno")
@@ -71,7 +69,6 @@ class TestcontainersInfrastructureIntegrationTests extends AbstractExtensionTest
 		ProjectRequest request = createProjectRequest("testcontainers");
 		request.setLanguage("groovy");
 		ProjectStructure project = generateProject(request);
-
 		assertThat(project).textFile("src/test/groovy/com/example/demo/TestcontainersConfiguration.groovy")
 			.contains("import com.example.SimpleAnno")
 			.contains("import com.example.ParamAnno")
@@ -85,11 +82,9 @@ class TestcontainersInfrastructureIntegrationTests extends AbstractExtensionTest
 		@Bean
 		ServiceConnectionsCustomizer fakeInfrastructureCustomizer() {
 			return (serviceConnections) -> {
-
 				DockerService fakeDockerService = DockerService.withImageAndTag("fake-image:latest")
 					.website("https://example.com")
 					.build();
-
 				ServiceConnection connection = ServiceConnection
 					.ofContainer("fake", fakeDockerService, "com.example.FakeContainer", false)
 					.withAnnotation(ClassName.of("com.example.SimpleAnno"))
@@ -98,7 +93,6 @@ class TestcontainersInfrastructureIntegrationTests extends AbstractExtensionTest
 						annotation.set("booleanValue", true);
 						annotation.set("intValue", 42);
 					});
-
 				serviceConnections.addServiceConnection(connection);
 			};
 		}


### PR DESCRIPTION
Description
This PR enhances the ServiceConnection API to support custom annotations with attributes (parameters). This is a foundational change that enables the upcoming support for the @Ssl annotation required by newer versions of Elasticsearch (v8+), as originally discussed in #2162.

Changes

* Infrastructure: Introduced the AnnotationRequest record to store annotation class names alongside a Consumer<Annotation.Builder> for attribute customization.

 * API Evolution: Added withAnnotation(ClassName) and withAnnotation(ClassName, Consumer<Annotation.Builder>) to ServiceConnection. This approach elegantly delegates attribute type inference natively to the Initializr AST, allowing the seamless use of Strings, Booleans, and Integers without the need for manual string escaping.

* Tests: Added comprehensive integration tests covering these multiple attribute types to ensure correct generation across Java, Kotlin, and Groovy.

Fixes
Closes #2162