### PR TITLE
Generate Compose file and Testcontainers support for base driver starters

### DIFF
--- a/start-site/src/main/java/io/spring/start/site/extension/dependency/cassandra/CassandraProjectGenerationConfiguration.java
+++ b/start-site/src/main/java/io/spring/start/site/extension/dependency/cassandra/CassandraProjectGenerationConfiguration.java
@@ -67,7 +67,8 @@ class CassandraProjectGenerationConfiguration {
 	}
 
 	private boolean isCassandraEnabled(Build build) {
-		return build.dependencies().has("data-cassandra") || build.dependencies().has("data-cassandra-reactive")
+		return build.dependencies().has("cassandra") || build.dependencies().has("data-cassandra")
+				|| build.dependencies().has("data-cassandra-reactive")
 				|| build.dependencies().has("spring-ai-vectordb-cassandra")
 				|| build.dependencies().has("spring-ai-chat-memory-repository-cassandra");
 	}

--- a/start-site/src/main/java/io/spring/start/site/extension/dependency/elasticsearch/ElasticsearchProjectGenerationConfiguration.java
+++ b/start-site/src/main/java/io/spring/start/site/extension/dependency/elasticsearch/ElasticsearchProjectGenerationConfiguration.java
@@ -69,7 +69,7 @@ class ElasticsearchProjectGenerationConfiguration {
 	}
 
 	private boolean isElasticsearchEnabled(Build build) {
-		return build.dependencies().has("data-elasticsearch")
+		return build.dependencies().has("elasticsearch") || build.dependencies().has("data-elasticsearch")
 				|| build.dependencies().has("spring-ai-vectordb-elasticsearch");
 	}
 

--- a/start-site/src/main/java/io/spring/start/site/extension/dependency/mongodb/MongoDbProjectGenerationConfiguration.java
+++ b/start-site/src/main/java/io/spring/start/site/extension/dependency/mongodb/MongoDbProjectGenerationConfiguration.java
@@ -67,8 +67,9 @@ class MongoDbProjectGenerationConfiguration {
 	}
 
 	private boolean isMongoEnabled(Build build) {
-		return build.dependencies().has("data-mongodb") || build.dependencies().has("data-mongodb-reactive")
-				|| build.dependencies().has("session-data-mongodb");
+		return build.dependencies().has("mongodb") || build.dependencies().has("data-mongodb")
+				|| build.dependencies().has("data-mongodb-reactive") || build.dependencies().has("session-data-mongodb")
+				|| build.dependencies().has("spring-ai-chat-memory-repository-mongodb");
 	}
 
 }

--- a/start-site/src/main/java/io/spring/start/site/extension/dependency/neo4j/Neo4jProjectGenerationConfiguration.java
+++ b/start-site/src/main/java/io/spring/start/site/extension/dependency/neo4j/Neo4jProjectGenerationConfiguration.java
@@ -63,7 +63,8 @@ public class Neo4jProjectGenerationConfiguration {
 	}
 
 	private boolean isNeo4jEnabled(Build build) {
-		return build.dependencies().has("data-neo4j") || build.dependencies().has("spring-ai-vectordb-neo4j")
+		return build.dependencies().has("neo4j") || build.dependencies().has("data-neo4j")
+				|| build.dependencies().has("spring-ai-vectordb-neo4j")
 				|| build.dependencies().has("spring-ai-chat-memory-repository-neo4j");
 	}
 

--- a/start-site/src/main/java/io/spring/start/site/extension/dependency/testcontainers/TestcontainersModuleRegistry.java
+++ b/start-site/src/main/java/io/spring/start/site/extension/dependency/testcontainers/TestcontainersModuleRegistry.java
@@ -57,21 +57,22 @@ abstract class TestcontainersModuleRegistry {
 			.customizeHelpDocument(addReferenceLink("Consul Module", "consul/")));
 		builders.add(onDependencies("cloud-starter-vault-config").customizeBuild(addModule("vault", testcontainers))
 			.customizeHelpDocument(addReferenceLink("Vault Module", "vault/")));
-		builders.add(onDependencies("data-cassandra", "data-cassandra-reactive", "spring-ai-vectordb-cassandra",
-				"spring-ai-chat-memory-repository-cassandra")
+		builders.add(onDependencies("cassandra", "data-cassandra", "data-cassandra-reactive",
+				"spring-ai-vectordb-cassandra", "spring-ai-chat-memory-repository-cassandra")
 			.customizeBuild(addModule("cassandra", testcontainers, SupportedContainer.CASSANDRA))
 			.customizeHelpDocument(addReferenceLink("Cassandra Module", "databases/cassandra/")));
 		builders.add(onDependencies("data-couchbase", "data-couchbase-reactive")
 			.customizeBuild(addModule("couchbase", testcontainers))
 			.customizeHelpDocument(addReferenceLink("Couchbase Module", "databases/couchbase/")));
-		builders.add(onDependencies("data-elasticsearch", "spring-ai-vectordb-elasticsearch")
+		builders.add(onDependencies("elasticsearch", "data-elasticsearch", "spring-ai-vectordb-elasticsearch")
 			.customizeBuild(addModule("elasticsearch", testcontainers, SupportedContainer.ELASTICSEARCH))
 			.customizeHelpDocument(addReferenceLink("Elasticsearch Container", "elasticsearch/")));
-		builders.add(onDependencies("data-mongodb", "data-mongodb-reactive", "spring-ai-vectordb-mongodb-atlas",
-				"session-data-mongodb")
+		builders.add(onDependencies("mongodb", "data-mongodb", "data-mongodb-reactive",
+				"spring-ai-vectordb-mongodb-atlas", "session-data-mongodb", "spring-ai-chat-memory-repository-mongodb")
 			.customizeBuild(addModule("mongodb", testcontainers, SupportedContainer.MONGODB))
 			.customizeHelpDocument(addReferenceLink("MongoDB Module", "databases/mongodb/")));
-		builders.add(onDependencies("data-neo4j", "spring-ai-vectordb-neo4j", "spring-ai-chat-memory-repository-neo4j")
+		builders.add(onDependencies("neo4j", "data-neo4j", "spring-ai-vectordb-neo4j",
+				"spring-ai-chat-memory-repository-neo4j")
 			.customizeBuild(addModule("neo4j", testcontainers, SupportedContainer.NEO4J))
 			.customizeHelpDocument(addReferenceLink("Neo4j Module", "databases/neo4j/")));
 		builders.add(onDependencies("opentelemetry")

--- a/start-site/src/test/java/io/spring/start/site/extension/dependency/cassandra/CassandraProjectGenerationConfigurationTests.java
+++ b/start-site/src/test/java/io/spring/start/site/extension/dependency/cassandra/CassandraProjectGenerationConfigurationTests.java
@@ -70,6 +70,12 @@ class CassandraProjectGenerationConfigurationTests extends AbstractExtensionTest
 	}
 
 	@Test
+	void createsCassandraServiceWhenDriverIsSelected() {
+		ProjectRequest request = createProjectRequest(BOOT_VERSION, "docker-compose", "cassandra");
+		assertThat(composeFile(request)).hasSameContentAs(new ClassPathResource("compose/cassandra.yaml"));
+	}
+
+	@Test
 	void createsCassandraServiceWhenSpringAiChatMemoryIsSelected() {
 		ProjectRequest request = createProjectRequest(SupportedBootVersion.V3_5, "docker-compose",
 				"spring-ai-chat-memory-repository-cassandra");

--- a/start-site/src/test/java/io/spring/start/site/extension/dependency/elasticsearch/ElasticsearchProjectGenerationConfigurationTests.java
+++ b/start-site/src/test/java/io/spring/start/site/extension/dependency/elasticsearch/ElasticsearchProjectGenerationConfigurationTests.java
@@ -50,6 +50,12 @@ class ElasticsearchProjectGenerationConfigurationTests extends AbstractExtension
 	}
 
 	@Test
+	void createsElasticsearchServiceWhenDriverIsSelected() {
+		ProjectRequest request = createProjectRequest(BOOT_VERSION, "docker-compose", "elasticsearch");
+		assertThat(composeFile(request)).hasSameContentAs(new ClassPathResource("compose/elasticsearch.yaml"));
+	}
+
+	@Test
 	void createsElasticsearchServiceWhenSpringAiModuleIsSelected() {
 		ProjectRequest request = createProjectRequest(SupportedBootVersion.V3_5, "docker-compose",
 				"spring-ai-vectordb-elasticsearch");

--- a/start-site/src/test/java/io/spring/start/site/extension/dependency/mongodb/MongoDbProjectGenerationConfigurationTests.java
+++ b/start-site/src/test/java/io/spring/start/site/extension/dependency/mongodb/MongoDbProjectGenerationConfigurationTests.java
@@ -18,6 +18,7 @@ package io.spring.start.site.extension.dependency.mongodb;
 
 import io.spring.initializr.generator.test.project.ProjectStructure;
 import io.spring.initializr.web.project.ProjectRequest;
+import io.spring.start.site.SupportedBootVersion;
 import io.spring.start.site.extension.AbstractExtensionTests;
 import org.junit.jupiter.api.Test;
 
@@ -61,6 +62,19 @@ class MongoDbProjectGenerationConfigurationTests extends AbstractExtensionTests 
 	@Test
 	void createsMongoDbServiceWhenSession() {
 		ProjectRequest request = createProjectRequest("docker-compose", "data-mongodb-reactive");
+		assertThat(composeFile(request)).hasSameContentAs(new ClassPathResource("compose/mongodb.yaml"));
+	}
+
+	@Test
+	void createsMongoDbServiceWhenDriverIsSelected() {
+		ProjectRequest request = createProjectRequest("docker-compose", "mongodb");
+		assertThat(composeFile(request)).hasSameContentAs(new ClassPathResource("compose/mongodb.yaml"));
+	}
+
+	@Test
+	void createsMongoDbServiceWhenSpringAiChatMemoryIsSelected() {
+		ProjectRequest request = createProjectRequest(SupportedBootVersion.V3_5, "docker-compose",
+				"spring-ai-chat-memory-repository-mongodb");
 		assertThat(composeFile(request)).hasSameContentAs(new ClassPathResource("compose/mongodb.yaml"));
 	}
 

--- a/start-site/src/test/java/io/spring/start/site/extension/dependency/neo4j/Neo4jProjectGenerationConfigurationTests.java
+++ b/start-site/src/test/java/io/spring/start/site/extension/dependency/neo4j/Neo4jProjectGenerationConfigurationTests.java
@@ -49,6 +49,12 @@ class Neo4jProjectGenerationConfigurationTests extends AbstractExtensionTests {
 	}
 
 	@Test
+	void createsNeo4jServiceWhenDriverIsSelected() {
+		ProjectRequest request = createProjectRequest(BOOT_VERSION, "docker-compose", "neo4j");
+		assertThat(composeFile(request)).hasSameContentAs(new ClassPathResource("compose/neo4j.yaml"));
+	}
+
+	@Test
 	void createsNeo4jServiceWhenSpringAiModuleIsSelected() {
 		ProjectRequest request = createProjectRequest(SupportedBootVersion.V3_5, "docker-compose",
 				"spring-ai-vectordb-neo4j");

--- a/start-site/src/test/java/io/spring/start/site/extension/dependency/testcontainers/TestcontainersProjectGenerationConfigurationTests.java
+++ b/start-site/src/test/java/io/spring/start/site/extension/dependency/testcontainers/TestcontainersProjectGenerationConfigurationTests.java
@@ -92,6 +92,7 @@ class TestcontainersProjectGenerationConfigurationTests extends AbstractExtensio
 
 	static Stream<Arguments> supportedTestcontainersSpringAiEntriesBuild() {
 		return Stream.of(Arguments.arguments("spring-ai-chat-memory-repository-cassandra", "cassandra"),
+				Arguments.arguments("spring-ai-chat-memory-repository-mongodb", "mongodb"),
 				Arguments.arguments("spring-ai-chat-memory-repository-neo4j", "neo4j"),
 				Arguments.arguments("spring-ai-vectordb-chroma", "chromadb"),
 				Arguments.arguments("spring-ai-vectordb-mariadb", "mariadb"),
@@ -146,6 +147,28 @@ class TestcontainersProjectGenerationConfigurationTests extends AbstractExtensio
 				Arguments.arguments("pulsar-reactive", "https://java.testcontainers.org/modules/pulsar/"),
 				Arguments.arguments("solace", "https://java.testcontainers.org/modules/solace/"),
 				Arguments.arguments("sqlserver", "https://java.testcontainers.org/modules/databases/mssqlserver/"));
+	}
+
+	@ParameterizedTest
+	@MethodSource("supportedEntriesHelpDocumentBoot4")
+	void linkToSupportedEntriesWhenTestContainerIsPresentIsAddedBoot4(String dependencyId, String docHref) {
+		ProjectRequest request = createProjectRequest(SupportedBootVersion.V4_0, "testcontainers", dependencyId);
+		assertThat(helpDocument(request)).contains(docHref);
+	}
+
+	@ParameterizedTest
+	@MethodSource("supportedEntriesHelpDocumentBoot4")
+	void linkToSupportedEntriesWhenTestContainerIsNotPresentIsNotAddedBoot4(String dependencyId, String docHref) {
+		ProjectRequest request = createProjectRequest(SupportedBootVersion.V4_0, dependencyId);
+		assertThat(helpDocument(request)).doesNotContain(docHref);
+	}
+
+	static Stream<Arguments> supportedEntriesHelpDocumentBoot4() {
+		return Stream.of(
+				Arguments.arguments("cassandra", "https://java.testcontainers.org/modules/databases/cassandra/"),
+				Arguments.arguments("elasticsearch", "https://java.testcontainers.org/modules/elasticsearch/"),
+				Arguments.arguments("mongodb", "https://java.testcontainers.org/modules/databases/mongodb/"),
+				Arguments.arguments("neo4j", "https://java.testcontainers.org/modules/databases/neo4j/"));
 	}
 
 	@Test


### PR DESCRIPTION
Wire up the Spring Boot 4.0 base driver dependency IDs (cassandra,
neo4j, elasticsearch, mongodb) for Docker Compose file generation and
Testcontainers support. Also add missing
`spring-ai-chat-memory-repository-mongodb` to MongoDB project generation.

Signed-off-by: Eddú Meléndez <eddu.melendez@gmail.com>
