### PR TITLE
Let the 'More' button toggle the dropdown state

### DIFF
--- a/USING.adoc
+++ b/USING.adoc
@@ -143,7 +143,7 @@ easily. If you are writing a tutorial that requires certain dependencies to be s
 you can also generate a link that you can use as a reference.
 
 To use this feature, simply use the UI like you would do to create a new project. Once
-you're done, click the "Share" button. A pop-up opens with a generated link with a handy
+you're done, click the "..." (More) button and select "Share". A pop-up opens with a generated link with a handy
 "copy" button to copy the link to your clipboard.
 
 The link contains all settings that are available on start.spring.io. You can shorten it

--- a/start-client/src/components/common/builder/Fields.js
+++ b/start-client/src/components/common/builder/Fields.js
@@ -196,9 +196,9 @@ function Fields({
         <span className='dropdown' ref={wrapper}>
           <Button
             className={`last-child ${dropdown ? 'clicked' : ''}`}
-            id='favorite-add'
+            id='more-button'
             onClick={() => {
-              setDropdown(!dropdown)
+              setDropdown(prev => !prev)
             }}
           >
             ...

--- a/start-client/src/components/common/builder/Fields.js
+++ b/start-client/src/components/common/builder/Fields.js
@@ -198,7 +198,7 @@ function Fields({
             className={`last-child ${dropdown ? 'clicked' : ''}`}
             id='favorite-add'
             onClick={() => {
-              setDropdown(true)
+              setDropdown(!dropdown)
             }}
           >
             ...


### PR DESCRIPTION
Improved UX by making the 'More' button labeled with favorite-add toggles the dropdown state instead of making it for open only

<!--
Thanks for contributing to start.spring.io Please review the following notes before
submitting you pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Proposal for New Entries

STOP! If your contribution suggests the addition of a new entry, please do not submit it
Rather create a "New Entry Proposal" issue as we need some information from you before
proceeding.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->

**Description**
This PR improves the UX of the 'More' button (associated with the favorite/share functionality).


**The Problem**
Previously, the button was configured to only trigger the open state of the dropdown. Clicking the button a second time while the dropdown was already visible would not close it (or would immediately re-open it), forcing users to click elsewhere on the screen to dismiss the menu.

**The Fix**
Updated the click handler in src/components/common/builder/Fields.js to properly toggle the state. The button now acts as a true toggle:


Click 1: Opens the dropdown.

Click 2: Closes the dropdown.

_Why this is useful_
This aligns the "More" button behavior with standard UI patterns found elsewhere in the Spring Initializr interface, providing a more predictable and fluid experience for developers interacting with the Share and Bookmark features.
