### PR TITLE
Hibernate enhancement contribution declares a deprecated property

### DIFF
--- a/start-site/src/main/java/io/spring/start/site/extension/dependency/graalvm/HibernatePluginGradleBuildCustomizer.java
+++ b/start-site/src/main/java/io/spring/start/site/extension/dependency/graalvm/HibernatePluginGradleBuildCustomizer.java
@@ -19,13 +19,18 @@ package io.spring.start.site.extension.dependency.graalvm;
 import io.spring.initializr.generator.buildsystem.gradle.GradleBuild;
 import io.spring.initializr.generator.spring.build.BuildCustomizer;
 import io.spring.initializr.generator.version.Version;
+import io.spring.initializr.generator.version.VersionParser;
+import io.spring.initializr.generator.version.VersionRange;
 
 /**
  * A {@link BuildCustomizer} for projects using the Groovy DSL with GraalVm and Hibernate.
  *
  * @author Stephane Nicoll
+ * @author Taewoong Kim
  */
 class HibernatePluginGradleBuildCustomizer implements BuildCustomizer<GradleBuild> {
+
+	private static final VersionRange HIBERNATE_7_1_OR_LATER = VersionParser.DEFAULT.parseRange("7.1.0");
 
 	private final Version hibernateVersion;
 
@@ -36,9 +41,15 @@ class HibernatePluginGradleBuildCustomizer implements BuildCustomizer<GradleBuil
 	@Override
 	public void customize(GradleBuild build) {
 		build.plugins().add("org.hibernate.orm", (plugin) -> plugin.setVersion(this.hibernateVersion.toString()));
-		build.extensions()
-			.customize("hibernate", (hibernate) -> hibernate.nested("enhancement",
-					(enhancement) -> enhancement.attribute("enableAssociationManagement", "true")));
+		build.extensions().customize("hibernate", (hibernate) -> hibernate.nested("enhancement", (enhancement) -> {
+			if (!isAssociationManagementDeprecated()) {
+				enhancement.attribute("enableAssociationManagement", "true");
+			}
+		}));
+	}
+
+	private boolean isAssociationManagementDeprecated() {
+		return HIBERNATE_7_1_OR_LATER.match(this.hibernateVersion);
 	}
 
 }

--- a/start-site/src/main/java/io/spring/start/site/extension/dependency/graalvm/HibernatePluginMavenBuildCustomizer.java
+++ b/start-site/src/main/java/io/spring/start/site/extension/dependency/graalvm/HibernatePluginMavenBuildCustomizer.java
@@ -27,6 +27,7 @@ import io.spring.initializr.generator.version.VersionRange;
  *
  * @author Stephane Nicoll
  * @author Moritz Halbritter
+ * @author Taewoong Kim
  */
 // See https://docs.hibernate.org/orm/7.1/userguide/html_single/#BytecodeEnhancement
 class HibernatePluginMavenBuildCustomizer implements BuildCustomizer<MavenBuild> {
@@ -44,8 +45,7 @@ class HibernatePluginMavenBuildCustomizer implements BuildCustomizer<MavenBuild>
 		if (isSpringBoot4OrLater()) {
 			build.plugins()
 				.add("org.hibernate.orm", "hibernate-maven-plugin", (plugin) -> plugin.version("${hibernate.version}")
-					.execution("enhance", (execution) -> execution.goal("enhance")
-						.configuration((configuration) -> configuration.add("enableAssociationManagement", "true"))));
+					.execution("enhance", (execution) -> execution.goal("enhance")));
 		}
 		else {
 			build.plugins()

--- a/start-site/src/test/java/io/spring/start/site/extension/dependency/graalvm/GraalVmProjectGenerationConfigurationTests.java
+++ b/start-site/src/test/java/io/spring/start/site/extension/dependency/graalvm/GraalVmProjectGenerationConfigurationTests.java
@@ -113,6 +113,19 @@ class GraalVmProjectGenerationConfigurationTests extends AbstractExtensionTests 
 	}
 
 	@Test
+	void gradleBuildAndKotlinDslWithJpaConfiguresHibernateEnhancePluginForBoot35() {
+		ProjectRequest request = createNativeProjectRequest(SupportedBootVersion.V3_5, "data-jpa");
+		assertThat(gradleKotlinDslBuild(request)).hasPlugin("org.hibernate.orm").lines().containsSequence(
+		// @formatter:off
+						"hibernate {",
+						"	enhancement {",
+						"		enableAssociationManagement = true",
+						"	}",
+						"}");
+		// @formatter:on
+	}
+
+	@Test
 	void mavenBuildWithoutJpaDoesNotConfigureHibernateEnhancePlugin() {
 		assertThat(mavenPom(createNativeProjectRequest(BOOT_VERSION))).doesNotContain("hibernate-maven-plugin");
 	}

--- a/start-site/src/test/java/io/spring/start/site/extension/dependency/graalvm/GraalVmProjectGenerationConfigurationTests.java
+++ b/start-site/src/test/java/io/spring/start/site/extension/dependency/graalvm/GraalVmProjectGenerationConfigurationTests.java
@@ -82,6 +82,18 @@ class GraalVmProjectGenerationConfigurationTests extends AbstractExtensionTests 
 		// @formatter:off
 				"hibernate {",
 				"	enhancement {",
+				"	}",
+				"}");
+		// @formatter:on
+	}
+
+	@Test
+	void gradleBuildAndGroovyDslWithJpaConfiguresHibernateEnhancePluginForBoot35() {
+		ProjectRequest request = createNativeProjectRequest(SupportedBootVersion.V3_5, "data-jpa");
+		assertThat(gradleBuild(request)).hasPlugin("org.hibernate.orm").lines().containsSequence(
+		// @formatter:off
+				"hibernate {",
+				"	enhancement {",
 				"		enableAssociationManagement = true",
 				"	}",
 				"}");
@@ -95,7 +107,6 @@ class GraalVmProjectGenerationConfigurationTests extends AbstractExtensionTests 
 		// @formatter:off
 						"hibernate {",
 						"	enhancement {",
-						"		enableAssociationManagement = true",
 						"	}",
 						"}");
 		// @formatter:on
@@ -126,9 +137,6 @@ class GraalVmProjectGenerationConfigurationTests extends AbstractExtensionTests 
 				"						<goals>",
 				"							<goal>enhance</goal>",
 				"						</goals>",
-				"						<configuration>",
-				"							<enableAssociationManagement>true</enableAssociationManagement>",
-				"						</configuration>",
 				"					</execution>",
 				"				</executions>",
 				"			</plugin>");


### PR DESCRIPTION
Fixes #1913.

This PR updates the generated Hibernate bytecode enhancement configuration for projects using GraalVM Native Support and Spring Data JPA.

Hibernate ORM 7.1 explicitly deprecates automatic management of bidirectional association attributes for removal. 

The [7.1 migration guide](https://docs.hibernate.org/orm/7.1/migration-guide/#enhancement-options) recommends that applications manage both sides of bidirectional associations directly and shows the updated Gradle shape as `hibernate { enhancement {} }`. 

The [7.1 Javadoc](https://docs.hibernate.org/orm/7.1/javadocs/org/hibernate/bytecode/enhance/spi/EnhancementOptions.html#doBiDirectionalAssociationManagement()) marks `doBiDirectionalAssociationManagement()` as `@Deprecated(forRemoval = true, since = "7.1")`.

---

<img width="1077" height="754" alt="hibernate_docs" src="https://github.com/user-attachments/assets/9a642927-ad59-4266-8806-d2a784480a4e" />

---

This PR keeps Hibernate enhancement configured, but stops emitting the deprecated association-management option for Spring Boot 4 / Hibernate 7.1+ projects. The existing Spring Boot 3.5 / Hibernate 6 output is left unchanged.

I tested the generated projects locally and manually checked the output in IntelliJ IDEA against a local Initializr server.
