### PR TITLE
Make zipkin build configuration more minimal on Spring Boot 4.0 or later

### DIFF
--- a/start-site/src/main/java/io/spring/start/site/extension/dependency/observability/ObservabilityActuatorBuildCustomizer.java
+++ b/start-site/src/main/java/io/spring/start/site/extension/dependency/observability/ObservabilityActuatorBuildCustomizer.java
@@ -63,13 +63,18 @@ class ObservabilityActuatorBuildCustomizer implements BuildCustomizer<Build> {
 		}
 	}
 
+	@Override
+	public int getOrder() {
+		return ObservabilityDistributedTracingBuildCustomizer.ORDER + 1;
+	}
+
 	private boolean hasActuator(Build build) {
 		return build.dependencies().has("actuator");
 	}
 
 	private boolean needsActuator(Build build) {
 		if (isBoot4OrLater()) {
-			return hasTracing(build) || hasPullBasedMetrics(build);
+			return hasPullBasedMetrics(build);
 		}
 		else {
 			return hasTracing(build) || hasPullBasedMetrics(build) || hasPushBasedMetrics(build);

--- a/start-site/src/main/java/io/spring/start/site/extension/dependency/observability/ObservabilityDistributedTracingBuildCustomizer.java
+++ b/start-site/src/main/java/io/spring/start/site/extension/dependency/observability/ObservabilityDistributedTracingBuildCustomizer.java
@@ -32,6 +32,8 @@ import io.spring.initializr.generator.version.VersionRange;
  */
 class ObservabilityDistributedTracingBuildCustomizer implements BuildCustomizer<Build> {
 
+	static final int ORDER = 0;
+
 	private static final VersionRange SPRING_BOOT_4_OR_LATER = VersionParser.DEFAULT.parseRange("4.0.0-M1");
 
 	private static final String DISTRIBUTED_TRACING = "distributed-tracing";
@@ -45,20 +47,23 @@ class ObservabilityDistributedTracingBuildCustomizer implements BuildCustomizer<
 	@Override
 	public void customize(Build build) {
 		if (isBoot4OrLater()) {
-			if (hasTracingProvider(build)) {
-				build.dependencies().remove(DISTRIBUTED_TRACING);
-			}
+			handleBoot4(build);
 		}
-		else if (build.dependencies().has("zipkin") && !build.dependencies().has(DISTRIBUTED_TRACING)) {
-			build.dependencies().add(DISTRIBUTED_TRACING);
+		else {
+			handleBoot35(build);
 		}
-		if (build.dependencies().has("wavefront") && build.dependencies().has(DISTRIBUTED_TRACING)) {
-			build.dependencies()
-				.add("wavefront-tracing-reporter",
-						Dependency.withCoordinates("io.micrometer", "micrometer-tracing-reporter-wavefront")
-							.scope(DependencyScope.RUNTIME));
+	}
+
+	@Override
+	public int getOrder() {
+		return ORDER;
+	}
+
+	private void handleBoot4(Build build) {
+		if (hasTracingProvider(build)) {
+			build.dependencies().remove(DISTRIBUTED_TRACING);
 		}
-		if (build.dependencies().has(DISTRIBUTED_TRACING) && isBoot4OrLater()) {
+		else if (hasDistributedTracing(build)) {
 			build.dependencies()
 				.add("spring-boot-micrometer-tracing-brave",
 						Dependency.withCoordinates("org.springframework.boot", "spring-boot-micrometer-tracing-brave"));
@@ -69,8 +74,28 @@ class ObservabilityDistributedTracingBuildCustomizer implements BuildCustomizer<
 		}
 	}
 
+	private void handleBoot35(Build build) {
+		if (hasZipkin(build) && !hasDistributedTracing(build)) {
+			build.dependencies().add(DISTRIBUTED_TRACING);
+		}
+		if (build.dependencies().has("wavefront") && hasDistributedTracing(build)) {
+			build.dependencies()
+				.add("wavefront-tracing-reporter",
+						Dependency.withCoordinates("io.micrometer", "micrometer-tracing-reporter-wavefront")
+							.scope(DependencyScope.RUNTIME));
+		}
+	}
+
+	private boolean hasDistributedTracing(Build build) {
+		return build.dependencies().has(DISTRIBUTED_TRACING);
+	}
+
 	private boolean hasTracingProvider(Build build) {
-		return build.dependencies().has("zipkin") || build.dependencies().has("opentelemetry");
+		return hasZipkin(build) || build.dependencies().has("opentelemetry");
+	}
+
+	private boolean hasZipkin(Build build) {
+		return build.dependencies().has("zipkin");
 	}
 
 	private boolean isBoot4OrLater() {

--- a/start-site/src/main/java/io/spring/start/site/extension/dependency/observability/ObservabilityDistributedTracingBuildCustomizer.java
+++ b/start-site/src/main/java/io/spring/start/site/extension/dependency/observability/ObservabilityDistributedTracingBuildCustomizer.java
@@ -34,6 +34,8 @@ class ObservabilityDistributedTracingBuildCustomizer implements BuildCustomizer<
 
 	private static final VersionRange SPRING_BOOT_4_OR_LATER = VersionParser.DEFAULT.parseRange("4.0.0-M1");
 
+	private static final String DISTRIBUTED_TRACING = "distributed-tracing";
+
 	private final Version bootVersion;
 
 	ObservabilityDistributedTracingBuildCustomizer(Version bootVersion) {
@@ -42,17 +44,21 @@ class ObservabilityDistributedTracingBuildCustomizer implements BuildCustomizer<
 
 	@Override
 	public void customize(Build build) {
-		// Zipkin without distributed tracing make no sense
-		if (build.dependencies().has("zipkin") && !build.dependencies().has("distributed-tracing")) {
-			build.dependencies().add("distributed-tracing");
+		if (isBoot4OrLater()) {
+			if (hasTracingProvider(build)) {
+				build.dependencies().remove(DISTRIBUTED_TRACING);
+			}
 		}
-		if (build.dependencies().has("wavefront") && build.dependencies().has("distributed-tracing")) {
+		else if (build.dependencies().has("zipkin") && !build.dependencies().has(DISTRIBUTED_TRACING)) {
+			build.dependencies().add(DISTRIBUTED_TRACING);
+		}
+		if (build.dependencies().has("wavefront") && build.dependencies().has(DISTRIBUTED_TRACING)) {
 			build.dependencies()
 				.add("wavefront-tracing-reporter",
 						Dependency.withCoordinates("io.micrometer", "micrometer-tracing-reporter-wavefront")
 							.scope(DependencyScope.RUNTIME));
 		}
-		if (build.dependencies().has("distributed-tracing") && isBoot4OrLater()) {
+		if (build.dependencies().has(DISTRIBUTED_TRACING) && isBoot4OrLater()) {
 			build.dependencies()
 				.add("spring-boot-micrometer-tracing-brave",
 						Dependency.withCoordinates("org.springframework.boot", "spring-boot-micrometer-tracing-brave"));
@@ -61,6 +67,10 @@ class ObservabilityDistributedTracingBuildCustomizer implements BuildCustomizer<
 						Dependency.withCoordinates("org.springframework.boot", "spring-boot-micrometer-tracing-test")
 							.scope(DependencyScope.TEST_COMPILE));
 		}
+	}
+
+	private boolean hasTracingProvider(Build build) {
+		return build.dependencies().has("zipkin") || build.dependencies().has("opentelemetry");
 	}
 
 	private boolean isBoot4OrLater() {

--- a/start-site/src/main/java/io/spring/start/site/extension/dependency/observability/ObservabilityHelpDocumentCustomizer.java
+++ b/start-site/src/main/java/io/spring/start/site/extension/dependency/observability/ObservabilityHelpDocumentCustomizer.java
@@ -40,7 +40,7 @@ public class ObservabilityHelpDocumentCustomizer implements HelpDocumentCustomiz
 
 	@Override
 	public void customize(HelpDocument document) {
-		if (this.build.dependencies().has("distributed-tracing")) {
+		if (this.build.dependencies().has("distributed-tracing") || this.build.dependencies().has("zipkin")) {
 			document.gettingStarted()
 				.addReferenceDocLink("https://docs.micrometer.io/tracing/reference/index.html",
 						"Distributed Tracing Reference Guide");

--- a/start-site/src/main/java/io/spring/start/site/extension/dependency/observability/ObservabilityHelpDocumentCustomizer.java
+++ b/start-site/src/main/java/io/spring/start/site/extension/dependency/observability/ObservabilityHelpDocumentCustomizer.java
@@ -40,7 +40,8 @@ public class ObservabilityHelpDocumentCustomizer implements HelpDocumentCustomiz
 
 	@Override
 	public void customize(HelpDocument document) {
-		if (this.build.dependencies().has("distributed-tracing") || this.build.dependencies().has("zipkin")) {
+		if (this.build.dependencies().has("distributed-tracing") || this.build.dependencies().has("zipkin")
+				|| this.build.dependencies().has("opentelemetry")) {
 			document.gettingStarted()
 				.addReferenceDocLink("https://docs.micrometer.io/tracing/reference/index.html",
 						"Distributed Tracing Reference Guide");

--- a/start-site/src/test/java/io/spring/start/site/extension/dependency/observability/ObservabilityActuatorBuildCustomizerTests.java
+++ b/start-site/src/test/java/io/spring/start/site/extension/dependency/observability/ObservabilityActuatorBuildCustomizerTests.java
@@ -44,13 +44,6 @@ class ObservabilityActuatorBuildCustomizerTests extends AbstractExtensionTests {
 	}
 
 	@ParameterizedTest
-	@ValueSource(strings = { "distributed-tracing", "zipkin" })
-	void actuatorIsAddedWithTracingEntriesForBoot4(String dependency) {
-		assertThat(generateProject(SupportedBootVersion.V4_0, dependency)).mavenBuild()
-			.hasDependency(getDependency("actuator"));
-	}
-
-	@ParameterizedTest
 	@ValueSource(strings = { "prometheus" })
 	void actuatorIsAddedWithPullBasedMetricsEntriesForBoot4(String dependency) {
 		assertThat(generateProject(SupportedBootVersion.V4_0, dependency)).mavenBuild()
@@ -69,9 +62,17 @@ class ObservabilityActuatorBuildCustomizerTests extends AbstractExtensionTests {
 			.hasDependency("org.springframework.boot", "spring-boot-starter-micrometer-metrics-test", null, "test");
 	}
 
+	@ParameterizedTest
+	@ValueSource(strings = { "distributed-tracing", "zipkin", "opentelemetry" })
+	void actuatorIsNotAddedWithTracingEntriesForBoot4(String dependency) {
+		Dependency actuator = getDependency("actuator");
+		assertThat(generateProject(SupportedBootVersion.V4_0, dependency)).mavenBuild()
+			.doesNotHaveDependency(actuator.getGroupId(), actuator.getArtifactId());
+	}
+
 	@Test
 	void shouldNotAddMicrometerMetricsIfActuatorIsThere() {
-		assertThat(generateProject(SupportedBootVersion.V4_0, "distributed-tracing", "datadog")).mavenBuild()
+		assertThat(generateProject(SupportedBootVersion.V4_0, "actuator", "datadog")).mavenBuild()
 			.hasDependency(getDependency("actuator"))
 			.doesNotHaveDependency("org.springframework.boot", "spring-boot-starter-micrometer-metrics")
 			.doesNotHaveDependency("org.springframework.boot", "spring-boot-starter-micrometer-metrics-test");

--- a/start-site/src/test/java/io/spring/start/site/extension/dependency/observability/ObservabilityDistributedTracingBuildCustomizerTests.java
+++ b/start-site/src/test/java/io/spring/start/site/extension/dependency/observability/ObservabilityDistributedTracingBuildCustomizerTests.java
@@ -35,6 +35,7 @@ class ObservabilityDistributedTracingBuildCustomizerTests extends AbstractExtens
 	void shouldAddMicrometerTracingOnBoot4OrLater() {
 		ProjectRequest request = createProjectRequest(SupportedBootVersion.V4_0, "distributed-tracing");
 		assertThat(mavenPom(request)).hasDependency("org.springframework.boot", "spring-boot-micrometer-tracing-brave");
+		assertThat(mavenPom(request)).hasDependency("io.micrometer", "micrometer-tracing-bridge-brave");
 		assertThat(mavenPom(request)).hasDependency("org.springframework.boot", "spring-boot-micrometer-tracing-test",
 				null, Dependency.SCOPE_TEST);
 	}
@@ -44,6 +45,67 @@ class ObservabilityDistributedTracingBuildCustomizerTests extends AbstractExtens
 		ProjectRequest request = createProjectRequest(SupportedBootVersion.V3_5, "distributed-tracing");
 		assertThat(mavenPom(request)).doesNotHaveDependency("org.springframework.boot",
 				"spring-boot-micrometer-tracing-brave");
+		assertThat(mavenPom(request)).doesNotHaveDependency("org.springframework.boot",
+				"spring-boot-micrometer-tracing-test");
+	}
+
+	@Test
+	void shouldMaintainCompatibilityIfZipkinIsPresentOnBootBefore4() {
+		ProjectRequest request = createProjectRequest(SupportedBootVersion.V3_5, "zipkin");
+		assertThat(mavenPom(request)).doesNotHaveDependency("org.springframework.boot", "spring-boot-starter-zipkin");
+		assertThat(mavenPom(request)).hasDependency("io.micrometer", "micrometer-tracing-bridge-brave");
+		assertThat(mavenPom(request)).hasDependency("io.zipkin.reporter2", "zipkin-reporter-brave");
+	}
+
+	@Test
+	void shouldNotAddMicrometerTracingIfZipkinIsPresentOnBoot4OrLater() {
+		ProjectRequest request = createProjectRequest(SupportedBootVersion.V4_0, "zipkin");
+		assertThat(mavenPom(request)).hasDependency("org.springframework.boot", "spring-boot-starter-zipkin");
+		assertThat(mavenPom(request)).doesNotHaveDependency("org.springframework.boot",
+				"spring-boot-micrometer-tracing-brave");
+		assertThat(mavenPom(request)).doesNotHaveDependency("io.micrometer", "micrometer-tracing-bridge-brave");
+		assertThat(mavenPom(request)).hasDependency("org.springframework.boot", "spring-boot-starter-zipkin-test", null,
+				Dependency.SCOPE_TEST);
+		assertThat(mavenPom(request)).doesNotHaveDependency("org.springframework.boot",
+				"spring-boot-micrometer-tracing-test");
+	}
+
+	@Test
+	void shouldNotAddMicrometerTracingIfZipkinAndDistributedTracingArePresentOnBoot4OrLater() {
+		ProjectRequest request = createProjectRequest(SupportedBootVersion.V4_0, "zipkin", "distributed-tracing");
+		assertThat(mavenPom(request)).hasDependency("org.springframework.boot", "spring-boot-starter-zipkin");
+		assertThat(mavenPom(request)).doesNotHaveDependency("org.springframework.boot",
+				"spring-boot-micrometer-tracing-brave");
+		assertThat(mavenPom(request)).doesNotHaveDependency("io.micrometer", "micrometer-tracing-bridge-brave");
+		assertThat(mavenPom(request)).hasDependency("org.springframework.boot", "spring-boot-starter-zipkin-test", null,
+				Dependency.SCOPE_TEST);
+		assertThat(mavenPom(request)).doesNotHaveDependency("org.springframework.boot",
+				"spring-boot-micrometer-tracing-test");
+	}
+
+	@Test
+	void shouldNotAddMicrometerTracingIfOpentelemetryIsPresentOnBoot4OrLater() {
+		ProjectRequest request = createProjectRequest(SupportedBootVersion.V4_0, "opentelemetry");
+		assertThat(mavenPom(request)).hasDependency("org.springframework.boot", "spring-boot-starter-opentelemetry");
+		assertThat(mavenPom(request)).doesNotHaveDependency("org.springframework.boot",
+				"spring-boot-micrometer-tracing-brave");
+		assertThat(mavenPom(request)).doesNotHaveDependency("io.micrometer", "micrometer-tracing-bridge-brave");
+		assertThat(mavenPom(request)).hasDependency("org.springframework.boot",
+				"spring-boot-starter-opentelemetry-test", null, Dependency.SCOPE_TEST);
+		assertThat(mavenPom(request)).doesNotHaveDependency("org.springframework.boot",
+				"spring-boot-micrometer-tracing-test");
+	}
+
+	@Test
+	void shouldNotAddMicrometerTracingIfOpentelemetryAndDistributedTracingArePresentOnBoot4OrLater() {
+		ProjectRequest request = createProjectRequest(SupportedBootVersion.V4_0, "opentelemetry",
+				"distributed-tracing");
+		assertThat(mavenPom(request)).hasDependency("org.springframework.boot", "spring-boot-starter-opentelemetry");
+		assertThat(mavenPom(request)).doesNotHaveDependency("org.springframework.boot",
+				"spring-boot-micrometer-tracing-brave");
+		assertThat(mavenPom(request)).doesNotHaveDependency("io.micrometer", "micrometer-tracing-bridge-brave");
+		assertThat(mavenPom(request)).hasDependency("org.springframework.boot",
+				"spring-boot-starter-opentelemetry-test", null, Dependency.SCOPE_TEST);
 		assertThat(mavenPom(request)).doesNotHaveDependency("org.springframework.boot",
 				"spring-boot-micrometer-tracing-test");
 	}

--- a/start-site/src/test/java/io/spring/start/site/extension/dependency/observability/ObservabilityHelpDocumentCustomizerTests.java
+++ b/start-site/src/test/java/io/spring/start/site/extension/dependency/observability/ObservabilityHelpDocumentCustomizerTests.java
@@ -38,6 +38,20 @@ class ObservabilityHelpDocumentCustomizerTests extends AbstractExtensionTests {
 	}
 
 	@Test
+	void linksAddedToHelpDocumentForZipkin() {
+		assertHelpDocument("zipkin").contains(
+				"* [Distributed Tracing Reference Guide](https://docs.micrometer.io/tracing/reference/index.html)",
+				"* [Getting Started with Distributed Tracing](https://docs.spring.io/spring-boot/4.0.0/reference/actuator/tracing.html)");
+	}
+
+	@Test
+	void linksAddedToHelpDocumentForOpenTelemetry() {
+		assertHelpDocument("opentelemetry").contains(
+				"* [Distributed Tracing Reference Guide](https://docs.micrometer.io/tracing/reference/index.html)",
+				"* [Getting Started with Distributed Tracing](https://docs.spring.io/spring-boot/4.0.0/reference/actuator/tracing.html)");
+	}
+
+	@Test
 	void linksNotAddedToHelpDocumentForBuildWithoutTracing() {
 		assertHelpDocument().noneMatch((line) -> line.contains("Tracing"));
 	}

--- a/start-site/src/test/java/io/spring/start/site/extension/dependency/observability/ObservabilityProjectGenerationConfigurationTests.java
+++ b/start-site/src/test/java/io/spring/start/site/extension/dependency/observability/ObservabilityProjectGenerationConfigurationTests.java
@@ -33,9 +33,25 @@ class ObservabilityProjectGenerationConfigurationTests extends AbstractExtension
 
 	@Test
 	void zipkinAddsDistributedTracingIfNecessary() {
+		assertThat(generateProject(SupportedBootVersion.V3_5, "zipkin")).mavenBuild()
+			.hasDependency(getDependency(SupportedBootVersion.V3_5, "zipkin"))
+			.hasDependency(getDependency(SupportedBootVersion.V3_5, "distributed-tracing"));
+	}
+
+	@Test
+	void zipkinShouldNotAddDistributedTracingIfNotNecessary() {
 		assertThat(generateProject(SupportedBootVersion.latest(), "zipkin")).mavenBuild()
 			.hasDependency(getDependency("zipkin"))
-			.hasDependency(getDependency("distributed-tracing"));
+			.doesNotHaveDependency("org.springframework.boot", "spring-boot-micrometer-tracing-brave")
+			.doesNotHaveDependency("io.micrometer", "micrometer-tracing-bridge-brave");
+	}
+
+	@Test
+	void opentelemetryShouldNotAddDistributedTracing() {
+		assertThat(generateProject(SupportedBootVersion.latest(), "opentelemetry", "distributed-tracing")).mavenBuild()
+			.hasDependency(getDependency("opentelemetry"))
+			.doesNotHaveDependency("org.springframework.boot", "spring-boot-micrometer-tracing-brave")
+			.doesNotHaveDependency("io.micrometer", "micrometer-tracing-bridge-brave");
 	}
 
 	@Test


### PR DESCRIPTION
<!--
Thanks for contributing to start.spring.io Please review the following notes before
submitting you pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Proposal for New Entries

STOP! If your contribution suggests the addition of a new entry, please do not submit it
Rather create a "New Entry Proposal" issue as we need some information from you before
proceeding.

Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->

We should use the minimal set of dependencies that work for the given purpose around observability. This PR resolves spring-io/start.spring.io#2196

## Dependencies mentioned on this PR

### zipkin

> Enable and expose span and trace IDs to Zipkin.

On Spring Boot 4.0, corresponds to `org.springframework.boot:spring-boot-starter-zipkin`
On Spring Boot 3.5, corresponds to `io.zipkin.reporter2:zipkin-reporter-brave`

### opentelemetry

> Publish metrics and traces in OpenTelemetry's OTLP format.

On Spring Boot 4.0, corresponds to `org.springframework.boot:spring-boot-starter-opentelemetry`
There is no Spring-owned started on Spring Boot 3.5.

### distributed-tracing

> Enable span and trace IDs in logs.

On Spring Boot 4.0, corresponds to the following dependencies:

```
org.springframework.boot:spring-boot-micrometer-tracing-brave
io.micrometer:micrometer-tracing-bridge-brave
```

On Spring Boot 3.5, corresponds to `io.micrometer:micrometer-tracing-bridge-brave`

## Current situation

- On Spring Boot 4, selecting `zipkin` will also add `distributed-tracing` to the generated project.
  - The zipkin starter already includes the Brave dependencies, making this a matter of explicitness only
- On Spring Boot 4, selecting either `zipkin` or `opentelemetry` in combination with `distributed-tracing` will also add the full `distributed-tracing` dependencies to the generated project.
  - In case of zipkin, this seems like simple duplication of Brave instrumentation. in case of otel, the Brave dependencies do not have to be there at all

## Goals
- On Spring Boot 4, Zipkin should not add distributed-tracing.
  - Opentelemetry already does not
- On Spring Boot 3.5, zipkin should continue to come with distributed-tracing
- If either Zipkin or Otel starter is present in combination with distributed-tracing, remove the redundant tracing implementation coming from distributed-tracing
  - Zipkin already includes Brave instrumentation to produce trace and span ids
  - Otel have their own tracer which also contributes trace and span ids to the logs

## Testing

I have started by making new tests first, letting them fail on the existing implementation, then tweak the project generation and customization in order to pass the updated tests.

I would like to take some more time to do some runtime testing with the generated projects. That means testing:

- [ ] a project with Zipkin on Spring Boot 4 (We made the  change of removing distributed-tracing)
- [ ] a project with Otel + distributed-tracing on Spring Boot 4 (This will be same as Otel only, we removed distributed-tracing for the reasons mentioned above)

## Examples

On the current implementation, adding `zipkin`:

```
dependencies {
  implementation("org.springframework.boot:spring-boot-micrometer-tracing-brave")
  implementation("org.springframework.boot:spring-boot-starter-actuator")
  implementation("org.springframework.boot:spring-boot-starter-zipkin")
  implementation("io.micrometer:micrometer-tracing-bridge-brave")
  testImplementation("org.springframework.boot:spring-boot-micrometer-tracing-test")
  testImplementation("org.springframework.boot:spring-boot-starter-zipkin-test")
  testRuntimeOnly("org.junit.platform:junit-platform-launcher")
}
```

Adding `zipkin` on the updated implementation:

```
dependencies {
  implementation("org.springframework.boot:spring-boot-starter-actuator")
  implementation("org.springframework.boot:spring-boot-starter-zipkin")
  testImplementation("org.springframework.boot:spring-boot-starter-zipkin-test")
  testRuntimeOnly("org.junit.platform:junit-platform-launcher")
}
```

On the current implementation, adding `opentelemetry` + `distributed-tracing`:

```
dependencies {
  implementation("org.springframework.boot:spring-boot-micrometer-tracing-brave")
  implementation("org.springframework.boot:spring-boot-starter-actuator")
  implementation("org.springframework.boot:spring-boot-starter-opentelemetry")
  implementation("io.micrometer:micrometer-tracing-bridge-brave")
  testImplementation("org.springframework.boot:spring-boot-micrometer-tracing-test")
  testImplementation("org.springframework.boot:spring-boot-starter-opentelemetry-test")
  testRuntimeOnly("org.junit.platform:junit-platform-launcher")
}
```

Adding `opentelemetry` + `distributed-tracing` on the updated implementation:

```
dependencies {
  implementation("org.springframework.boot:spring-boot-starter-actuator")
  implementation("org.springframework.boot:spring-boot-starter-opentelemetry")
  testImplementation("org.springframework.boot:spring-boot-starter-opentelemetry-test")
  testRuntimeOnly("org.junit.platform:junit-platform-launcher")
}
```

