### PR TITLE
Add community-maintained starters discovery page

### DIFF
--- a/start-client/src/components/Application.js
+++ b/start-client/src/components/Application.js
@@ -26,6 +26,7 @@ const Share = lazy(() => import('./common/share/Share'))
 const History = lazy(() => import('./common/history/History'))
 const HotKeys = lazy(() => import('./common/builder/HotKeys'))
 const Favorite = lazy(() => import('./common/favorite/Favorite'))
+const CommunityStarters = lazy(() => import('./common/community/CommunityStarters'))
 
 export default function Application() {
   const {
@@ -40,6 +41,7 @@ export default function Application() {
     favoriteOptions,
     list,
     dependencies,
+    community: communityOpen,
   } = useContext(AppContext)
   const {
     values,
@@ -77,6 +79,7 @@ export default function Application() {
         share: false,
         explore: false,
         nav: false,
+        community: false,
         history: favoriteOptions.back === 'history',
         favorite: favoriteOptions.back === 'favorite',
         favoriteAdd: false,
@@ -193,6 +196,7 @@ export default function Application() {
           open={favoriteOpen || false}
           onClose={onEscape}
         />
+        <CommunityStarters open={communityOpen || false} onClose={onEscape} />
       </Suspense>
     </>
   )

--- a/start-client/src/components/common/community/CommunityStarters.js
+++ b/start-client/src/components/common/community/CommunityStarters.js
@@ -1,0 +1,23 @@
+import '../../../styles/community.scss'
+
+import PropTypes from 'prop-types'
+import React from 'react'
+
+import Modal from './Modal'
+import {Overlay} from '../form'
+
+function CommunityStarters({open, onClose}) {
+  return (
+    <>
+      <Modal open={open || false} onClose={onClose} />
+      <Overlay open={open || false} />
+    </>
+  )
+}
+
+CommunityStarters.propTypes = {
+  open: PropTypes.bool.isRequired,
+  onClose: PropTypes.func.isRequired,
+}
+
+export default CommunityStarters

--- a/start-client/src/components/common/community/Modal.js
+++ b/start-client/src/components/common/community/Modal.js
@@ -1,0 +1,322 @@
+import get from 'lodash/get'
+import React, {useCallback, useContext, useEffect, useMemo, useRef, useState} from 'react'
+import {CSSTransition, TransitionGroup} from 'react-transition-group'
+import {clearAllBodyScrollLocks, disableBodyScroll} from 'body-scroll-lock'
+import CopyToClipboard from 'react-copy-to-clipboard'
+
+import starters from './starters.json'
+import {AppContext} from '../../reducer/App'
+import {InitializrContext} from '../../reducer/Initializr'
+import {IconSearch, IconTimes} from '../icons'
+
+// ─── Snippet helpers ─────────────────────────────────────────────────────────
+
+function buildMavenSnippet(groupId, artifactId) {
+  return `<dependency>
+  <groupId>${groupId}</groupId>
+  <artifactId>${artifactId}</artifactId>
+</dependency>`
+}
+
+function buildGradleSnippet(groupId, artifactId) {
+  return `implementation '${groupId}:${artifactId}'`
+}
+
+// ─── All unique tags ──────────────────────────────────────────────────────────
+
+const ALL_TAGS = ['All', ...Array.from(
+  starters.reduce((acc, s) => {
+    s.tags.forEach(t => acc.add(t))
+    return acc
+  }, new Set())
+).sort()]
+
+// ─── StarterCard ─────────────────────────────────────────────────────────────
+
+function StarterCard({starter}) {
+  const [tab, setTab] = useState('maven')
+  const [copied, setCopied] = useState(false)
+
+  const mavenSnippet = useMemo(
+    () => buildMavenSnippet(starter.groupId, starter.artifactId),
+    [starter.groupId, starter.artifactId]
+  )
+  const gradleSnippet = useMemo(
+    () => buildGradleSnippet(starter.groupId, starter.artifactId),
+    [starter.groupId, starter.artifactId]
+  )
+  const activeSnippet = tab === 'maven' ? mavenSnippet : gradleSnippet
+
+  const onCopy = useCallback(() => {
+    setCopied(true)
+    setTimeout(() => setCopied(false), 1500)
+  }, [])
+
+  return (
+    <div className='community-card'>
+      <div className='community-card-name'>{starter.name}</div>
+      <p className='community-card-description'>{starter.description}</p>
+      <div className='community-card-tags'>
+        {starter.tags.map(tag => (
+          <span key={tag}>{tag}</span>
+        ))}
+      </div>
+      <div className='community-card-snippet'>
+        <div className='snippet-tabs'>
+          <button
+            type='button'
+            className={`snippet-tab${tab === 'maven' ? ' active' : ''}`}
+            onClick={() => setTab('maven')}
+          >
+            Maven
+          </button>
+          <button
+            type='button'
+            className={`snippet-tab${tab === 'gradle' ? ' active' : ''}`}
+            onClick={() => setTab('gradle')}
+          >
+            Gradle
+          </button>
+        </div>
+        <div className='snippet-content'>
+          {activeSnippet}
+          <CopyToClipboard text={activeSnippet} onCopy={onCopy}>
+            <button type='button' className='snippet-copy'>
+              {copied ? 'Copied!' : 'Copy'}
+            </button>
+          </CopyToClipboard>
+        </div>
+      </div>
+      <div className='community-card-links'>
+        <a
+          href={starter.docUrl}
+          target='_blank'
+          rel='noopener noreferrer'
+        >
+          Documentation
+        </a>
+        <a
+          href={starter.repoUrl}
+          target='_blank'
+          rel='noopener noreferrer'
+        >
+          Repository
+        </a>
+      </div>
+    </div>
+  )
+}
+
+// ─── Modal ────────────────────────────────────────────────────────────────────
+
+function Modal({open, onClose}) {
+  const wrapper = useRef(null)
+  const searchRef = useRef(null)
+  const [query, setQuery] = useState('')
+  const [activeTag, setActiveTag] = useState('All')
+  const [whyOpen, setWhyOpen] = useState(false)
+
+  const {dispatch} = useContext(AppContext)
+  const {values} = useContext(InitializrContext)
+  const bootVersion = get(values, 'boot', '')
+
+  // Close on outside click
+  useEffect(() => {
+    const clickOutside = event => {
+      const children = get(wrapper, 'current')
+      if (children && !children.contains(event.target)) {
+        onClose()
+      }
+    }
+    document.addEventListener('mousedown', clickOutside)
+    return () => {
+      document.removeEventListener('mousedown', clickOutside)
+    }
+  }, [onClose])
+
+  // Scroll lock
+  useEffect(() => {
+    if (get(wrapper, 'current') && open) {
+      disableBodyScroll(get(wrapper, 'current'))
+    }
+    return () => {
+      clearAllBodyScrollLocks()
+    }
+  }, [wrapper, open])
+
+  // Focus search on open
+  useEffect(() => {
+    if (open && get(searchRef, 'current')) {
+      searchRef.current.focus()
+    }
+    if (!open) {
+      setQuery('')
+      setActiveTag('All')
+      setWhyOpen(false)
+    }
+  }, [open])
+
+  const filteredStarters = useMemo(() => {
+    const q = query.trim().toLowerCase()
+    return starters.filter(s => {
+      const matchesTag = activeTag === 'All' || s.tags.includes(activeTag)
+      if (!q) return matchesTag
+      const matchesQuery =
+        s.name.toLowerCase().includes(q) ||
+        s.description.toLowerCase().includes(q) ||
+        s.groupId.toLowerCase().includes(q) ||
+        s.artifactId.toLowerCase().includes(q) ||
+        s.tags.some(t => t.toLowerCase().includes(q))
+      return matchesTag && matchesQuery
+    })
+  }, [query, activeTag])
+
+  return (
+    <TransitionGroup component={null}>
+      {open && (
+        <CSSTransition classNames='community' timeout={300}>
+          <div className='modal-community'>
+            <div className='modal-community-container' ref={wrapper}>
+              <div className='modal-header'>
+                <h1>Community Starters</h1>
+                <a
+                  href='/#'
+                  onClick={e => {
+                    e.preventDefault()
+                    onClose()
+                  }}
+                  className='button'
+                >
+                  <span className='button-content' tabIndex='-1'>
+                    <span>Close</span>
+                    <span className='secondary desktop-only'>ESC</span>
+                  </span>
+                </a>
+              </div>
+              <div className='modal-content'>
+                {/* Version-aware notice — directly addresses maintainer concern */}
+                <div className='community-notice'>
+                  <div className='community-notice-boot'>
+                    Spring Boot version
+                    <span className='boot-badge'>{bootVersion}</span>
+                  </div>
+                  <p>
+                    Additional community-maintained starters are not part of the curated Spring Initializr dependency catalog.
+                    <br /><br />
+                    Community starters are independently maintained by their respective
+                    projects. Check each project&apos;s documentation to verify
+                    compatibility with your selected Spring Boot version.
+                  </p>
+                </div>
+
+                {/* Why section */}
+                <div className='community-why'>
+                  <button
+                    type='button'
+                    className='community-why-toggle'
+                    onClick={() => setWhyOpen(prev => !prev)}
+                  >
+                    Why aren&apos;t these starters in Spring Initializr?
+                  </button>
+                  {whyOpen && (
+                    <div className='community-why-content'>
+                      <p>
+                        Spring Initializr uses a curated dependency catalog. Dependencies
+                        are only included after the Spring team has verified that they
+                        integrate smoothly with Spring Boot, are actively maintained, and
+                        meet the quality bar expected by the community.
+                      </p>
+                      <p>
+                        Community starters listed here are well-known, widely used projects
+                        that have not yet been incorporated into the curated catalog. They
+                        are maintained by their own teams and may require additional
+                        configuration steps not covered by Initializr.
+                      </p>
+                    </div>
+                  )}
+                </div>
+
+                {/* Search */}
+                <div className='community-search'>
+                  <div className='community-search-input-wrap'>
+                    <IconSearch />
+                    <input
+                      ref={searchRef}
+                      id='community-search-input'
+                      type='text'
+                      placeholder='Search starters…'
+                      value={query}
+                      onChange={e => setQuery(e.target.value)}
+                    />
+                    {query && (
+                      <button
+                        type='button'
+                        className='community-search-clear'
+                        onClick={() => setQuery('')}
+                        aria-label='Clear search'
+                      >
+                        <IconTimes />
+                      </button>
+                    )}
+                  </div>
+                </div>
+
+                {/* Tags */}
+                <div className='community-tags'>
+                  {ALL_TAGS.map(tag => (
+                    <button
+                      key={tag}
+                      type='button'
+                      className={`community-tag${activeTag === tag ? ' active' : ''}`}
+                      onClick={() => setActiveTag(tag)}
+                    >
+                      {tag}
+                    </button>
+                  ))}
+                </div>
+
+                {/* Results count */}
+                <div className='community-results-count'>
+                  {filteredStarters.length === starters.length
+                    ? `${starters.length} community starters`
+                    : `${filteredStarters.length} of ${starters.length} starters`}
+                </div>
+
+                {/* Grid */}
+                {filteredStarters.length > 0 ? (
+                  <div className='community-grid'>
+                    {filteredStarters.map(starter => (
+                      <StarterCard key={starter.id} starter={starter} />
+                    ))}
+                  </div>
+                ) : (
+                  <div className='community-empty'>
+                    <IconSearch />
+                    <p>No starters match your search.</p>
+                  </div>
+                )}
+              </div>
+              <div className='modal-action'>
+                <a
+                  href='/#'
+                  onClick={e => {
+                    e.preventDefault()
+                    onClose()
+                  }}
+                  className='button'
+                >
+                  <span className='button-content' tabIndex='-1'>
+                    <span>Close</span>
+                    <span className='secondary desktop-only'>ESC</span>
+                  </span>
+                </a>
+              </div>
+            </div>
+          </div>
+        </CSSTransition>
+      )}
+    </TransitionGroup>
+  )
+}
+
+export default Modal

--- a/start-client/src/components/common/community/__tests__/CommunityStarters.js
+++ b/start-client/src/components/common/community/__tests__/CommunityStarters.js
@@ -1,0 +1,155 @@
+import starters from '../starters.json'
+
+// ─── Data integrity tests ─────────────────────────────────────────────────────
+
+describe('starters.json', () => {
+  it('should be a non-empty array', () => {
+    expect(Array.isArray(starters)).toBe(true)
+    expect(starters.length).toBeGreaterThan(0)
+  })
+
+  it('every entry should have all required fields with non-empty string values', () => {
+    const requiredFields = [
+      'id',
+      'name',
+      'description',
+      'groupId',
+      'artifactId',
+      'docUrl',
+      'repoUrl',
+    ]
+    starters.forEach(starter => {
+      requiredFields.forEach(field => {
+        expect(starter[field]).toBeDefined()
+        expect(typeof starter[field]).toBe('string')
+        expect(starter[field].trim().length).toBeGreaterThan(0)
+      })
+    })
+  })
+
+  it('every entry should have a non-empty tags array', () => {
+    starters.forEach(starter => {
+      expect(Array.isArray(starter.tags)).toBe(true)
+      expect(starter.tags.length).toBeGreaterThan(0)
+      starter.tags.forEach(tag => {
+        expect(typeof tag).toBe('string')
+        expect(tag.trim().length).toBeGreaterThan(0)
+      })
+    })
+  })
+
+  it('every id should be unique', () => {
+    const ids = starters.map(s => s.id)
+    const unique = new Set(ids)
+    expect(unique.size).toBe(ids.length)
+  })
+
+  it('docUrl and repoUrl should be valid URLs', () => {
+    starters.forEach(starter => {
+      expect(starter.docUrl).toMatch(/^https?:\/\//)
+      expect(starter.repoUrl).toMatch(/^https?:\/\//)
+    })
+  })
+
+  it('groupId and artifactId should follow Maven coordinate conventions', () => {
+    starters.forEach(starter => {
+      // groupId: at least one dot-separated segment
+      expect(starter.groupId).toMatch(/^[a-zA-Z0-9._-]+$/)
+      // artifactId: lowercase, hyphens allowed
+      expect(starter.artifactId).toMatch(/^[a-zA-Z0-9._-]+$/)
+    })
+  })
+})
+
+// ─── Snippet generation helpers ───────────────────────────────────────────────
+
+function buildMavenSnippet(groupId, artifactId) {
+  return `<dependency>
+  <groupId>${groupId}</groupId>
+  <artifactId>${artifactId}</artifactId>
+</dependency>`
+}
+
+function buildGradleSnippet(groupId, artifactId) {
+  return `implementation '${groupId}:${artifactId}'`
+}
+
+describe('buildMavenSnippet', () => {
+  it('should produce a valid Maven dependency XML snippet', () => {
+    const snippet = buildMavenSnippet('org.apache.camel.springboot', 'camel-spring-boot-starter')
+    expect(snippet).toContain('<dependency>')
+    expect(snippet).toContain('<groupId>org.apache.camel.springboot</groupId>')
+    expect(snippet).toContain('<artifactId>camel-spring-boot-starter</artifactId>')
+    expect(snippet).toContain('</dependency>')
+  })
+})
+
+describe('buildGradleSnippet', () => {
+  it('should produce a valid Gradle implementation snippet', () => {
+    const snippet = buildGradleSnippet('org.apache.camel.springboot', 'camel-spring-boot-starter')
+    expect(snippet).toBe(
+      "implementation 'org.apache.camel.springboot:camel-spring-boot-starter'"
+    )
+  })
+})
+
+// ─── Filtering logic ──────────────────────────────────────────────────────────
+
+function filterStarters(items, query, activeTag) {
+  const q = query.trim().toLowerCase()
+  return items.filter(s => {
+    const matchesTag = activeTag === 'All' || s.tags.includes(activeTag)
+    if (!q) return matchesTag
+    const matchesQuery =
+      s.name.toLowerCase().includes(q) ||
+      s.description.toLowerCase().includes(q) ||
+      s.groupId.toLowerCase().includes(q) ||
+      s.artifactId.toLowerCase().includes(q) ||
+      s.tags.some(t => t.toLowerCase().includes(q))
+    return matchesTag && matchesQuery
+  })
+}
+
+describe('filterStarters', () => {
+  it('should return all starters when query is empty and tag is All', () => {
+    const result = filterStarters(starters, '', 'All')
+    expect(result.length).toBe(starters.length)
+  })
+
+  it('should filter by name (case-insensitive)', () => {
+    const result = filterStarters(starters, 'camel', 'All')
+    expect(result.length).toBeGreaterThan(0)
+    result.forEach(s => {
+      expect(s.name.toLowerCase()).toContain('camel')
+    })
+  })
+
+  it('should filter by groupId', () => {
+    const result = filterStarters(starters, 'org.flowable', 'All')
+    expect(result.length).toBeGreaterThan(0)
+    result.forEach(s => {
+      expect(s.groupId.toLowerCase()).toContain('flowable')
+    })
+  })
+
+  it('should filter by tag when activeTag is set', () => {
+    const result = filterStarters(starters, '', 'workflow')
+    result.forEach(s => {
+      expect(s.tags).toContain('workflow')
+    })
+  })
+
+  it('should return empty array when nothing matches', () => {
+    const result = filterStarters(starters, 'xyzzy_no_match_guaranteed', 'All')
+    expect(result.length).toBe(0)
+  })
+
+  it('should apply both query and tag filter simultaneously', () => {
+    // "integration" in both query and as a real tag
+    const result = filterStarters(starters, 'camel', 'integration')
+    // Apache Camel has both
+    result.forEach(s => {
+      expect(s.tags).toContain('integration')
+    })
+  })
+})

--- a/start-client/src/components/common/community/index.js
+++ b/start-client/src/components/common/community/index.js
@@ -1,0 +1,1 @@
+export {default as CommunityStarters} from './CommunityStarters'

--- a/start-client/src/components/common/community/starters.json
+++ b/start-client/src/components/common/community/starters.json
@@ -1,0 +1,92 @@
+[
+  {
+    "id": "apache-camel",
+    "name": "Apache Camel",
+    "description": "Enterprise Integration Patterns library with 300+ components for connecting any system. Build routes using a fluent Java DSL, XML, or YAML inside your Spring Boot application.",
+    "groupId": "org.apache.camel.springboot",
+    "artifactId": "camel-spring-boot-starter",
+    "docUrl": "https://camel.apache.org/camel-spring-boot/latest/",
+    "repoUrl": "https://github.com/apache/camel-spring-boot",
+    "tags": ["integration", "messaging", "routing"]
+  },
+  {
+    "id": "camunda-bpm",
+    "name": "Camunda BPM",
+    "description": "BPMN 2.0 workflow and decision automation engine. Model, execute, and monitor business processes and decisions with a fully embedded process engine.",
+    "groupId": "org.camunda.bpm.springboot",
+    "artifactId": "camunda-bpm-spring-boot-starter",
+    "docUrl": "https://docs.camunda.org/manual/latest/user-guide/spring-boot-integration/",
+    "repoUrl": "https://github.com/camunda/camunda-bpm-spring-boot-starter",
+    "tags": ["workflow", "bpmn", "process"]
+  },
+  {
+    "id": "flowable",
+    "name": "Flowable",
+    "description": "Lightweight and battle-hardened Business Process Management (BPM) platform. Supports BPMN 2.0, CMMN, and DMN with a full-featured Spring Boot integration.",
+    "groupId": "org.flowable",
+    "artifactId": "flowable-spring-boot-starter",
+    "docUrl": "https://www.flowable.com/open-source/docs/",
+    "repoUrl": "https://github.com/flowable/flowable-engine",
+    "tags": ["workflow", "bpmn", "process"]
+  },
+  {
+    "id": "axon-framework",
+    "name": "Axon Framework",
+    "description": "Framework for building event-driven microservices using CQRS, Event Sourcing, and Domain-Driven Design patterns with seamless Spring Boot integration.",
+    "groupId": "org.axonframework.springboot",
+    "artifactId": "axon-spring-boot-starter",
+    "docUrl": "https://docs.axoniq.io/axon-framework/",
+    "repoUrl": "https://github.com/AxonFramework/AxonFramework",
+    "tags": ["event-sourcing", "cqrs", "messaging", "ddd"]
+  },
+  {
+    "id": "bucket4j",
+    "name": "Bucket4j Spring Boot Starter",
+    "description": "Rate-limiting and throttling library based on the token-bucket algorithm. Integrates with Spring Boot to provide declarative rate limiting via annotations and filters.",
+    "groupId": "com.giffing.bucket4j.spring.boot.starter",
+    "artifactId": "bucket4j-spring-boot-starter",
+    "docUrl": "https://github.com/MarcGiffing/bucket4j-spring-boot-starter#readme",
+    "repoUrl": "https://github.com/MarcGiffing/bucket4j-spring-boot-starter",
+    "tags": ["rate-limiting", "security", "web"]
+  },
+  {
+    "id": "logbook",
+    "name": "Zalando Logbook",
+    "description": "Extensible library for HTTP request and response logging. Integrates with Spring Boot to provide configurable, structured HTTP traffic logging for debugging and auditing.",
+    "groupId": "org.zalando",
+    "artifactId": "logbook-spring-boot-starter",
+    "docUrl": "https://github.com/zalando/logbook#spring-boot-starter",
+    "repoUrl": "https://github.com/zalando/logbook",
+    "tags": ["logging", "observability", "web"]
+  },
+  {
+    "id": "problem-spring-web",
+    "name": "Zalando Problem Spring Web",
+    "description": "Library for producing application/problem+json (RFC 7807) responses from Spring MVC and Spring WebFlux, providing a standard error response format for REST APIs.",
+    "groupId": "org.zalando",
+    "artifactId": "problem-spring-web-starter",
+    "docUrl": "https://github.com/zalando/problem-spring-web#readme",
+    "repoUrl": "https://github.com/zalando/problem-spring-web",
+    "tags": ["web", "error-handling", "rest"]
+  },
+  {
+    "id": "togglz",
+    "name": "Togglz",
+    "description": "Feature flag / feature toggle library for Java and Spring Boot. Control feature rollout at runtime without redeployment, with support for various activation strategies.",
+    "groupId": "org.togglz",
+    "artifactId": "togglz-spring-boot-starter",
+    "docUrl": "https://www.togglz.org/documentation/spring-boot-starter.html",
+    "repoUrl": "https://github.com/togglz/togglz",
+    "tags": ["feature-flags", "operations"]
+  },
+  {
+    "id": "springwolf",
+    "name": "Springwolf",
+    "description": "Automated AsyncAPI documentation for Spring Boot applications. Generates interactive AsyncAPI docs for Kafka, RabbitMQ, SQS, and other async protocols — the Swagger for async APIs.",
+    "groupId": "io.github.springwolf",
+    "artifactId": "springwolf-core",
+    "docUrl": "https://www.springwolf.dev/docs/",
+    "repoUrl": "https://github.com/springwolf/springwolf-core",
+    "tags": ["documentation", "messaging", "kafka", "async"]
+  }
+]

--- a/start-client/src/components/common/layout/SideLeft.js
+++ b/start-client/src/components/common/layout/SideLeft.js
@@ -198,6 +198,21 @@ function SideLeft() {
                           Migrate Spring Boot 3.5 to 4.0
                         </a>
                       </li>
+                      <li>
+                        <button
+                          id='ql-community-starters'
+                          type='button'
+                          className='navigation-link-button'
+                          onClick={() => {
+                            dispatch({
+                              type: 'UPDATE',
+                              payload: {nav: false, community: true},
+                            })
+                          }}
+                        >
+                          Explore Additional Community-Maintained Starters
+                        </button>
+                      </li>
                     </ul>
                   </div>
                   <div className='is-mobile'>

--- a/start-client/src/components/reducer/App.js
+++ b/start-client/src/components/reducer/App.js
@@ -15,6 +15,7 @@ export const defaultAppContext = {
   history: false,
   favorite: false,
   favoriteAdd: false,
+  community: false,
   nav: false,
   list: false,
   theme: 'light',

--- a/start-client/src/styles/_main.scss
+++ b/start-client/src/styles/_main.scss
@@ -732,12 +732,19 @@ button.button {
     padding: 0;
     li {
       list-style: none;
-      a {
+      a,
+      button.navigation-link-button {
         font-size: 32px;
         line-height: 60px;
         font-weight: 600;
         color: white;
         text-decoration: none;
+        cursor: pointer;
+        background: none;
+        border: 0;
+        padding: 0;
+        font-family: $spring-font-family;
+        display: block;
         &:hover {
           color: #222;
         }

--- a/start-client/src/styles/community.scss
+++ b/start-client/src/styles/community.scss
@@ -1,0 +1,566 @@
+@use 'variables' as *;
+@use 'mixins' as *;
+@use 'responsive';
+@use 'sass:color';
+
+$community-max-width: 1100px;
+
+.modal-community {
+  z-index: 999;
+  position: fixed;
+  top: 50px;
+  left: 0;
+  right: 0;
+
+  .modal-community-container {
+    max-width: $community-max-width;
+    margin: 0 auto;
+    background: white;
+  }
+
+  @include transition(all $spring-transition-duration);
+
+  .modal-content {
+    padding: $spring-8points * 3;
+    padding-top: $spring-8points * 1.5;
+    padding-bottom: $spring-8points * 2;
+    max-height: 75vh;
+    overflow: auto;
+  }
+
+  .modal-header {
+    position: relative;
+    padding: 6px $spring-8points * 3 2px;
+    border-bottom: 1px solid #ebebeb;
+
+    h1 {
+      font-size: $spring-8points * 2.5;
+      line-height: $spring-8points * 3;
+      font-weight: 600;
+    }
+
+    .button {
+      position: absolute;
+      top: 11px;
+      right: 11px;
+      font-size: $spring-font-size - 3;
+      line-height: 0.7rem;
+      margin-right: 0;
+    }
+  }
+
+  .modal-action {
+    text-align: center;
+    border-top: 1px solid $light-border;
+    padding: 16px 0 8px;
+  }
+}
+
+// Version notice banner
+
+.community-notice {
+  background: $light-background-seconday;
+  border-left: 4px solid $light-primary;
+  border-radius: $spring-radius;
+  padding: $spring-8points * 1.5 $spring-8points * 2;
+  margin-bottom: $spring-8points * 2;
+  font-size: $spring-font-size-sm;
+  line-height: 1.6;
+
+  strong {
+    color: $light-primary;
+    font-weight: 600;
+  }
+
+  p {
+    margin: 0;
+    color: $light-color;
+  }
+
+  .community-notice-boot {
+    font-size: $spring-8points * 1.75;
+    font-weight: 600;
+    margin-bottom: $spring-8points * 0.5;
+
+    .boot-badge {
+      display: inline-block;
+      background: $light-primary;
+      color: white;
+      font-size: $spring-font-size-sm - 1;
+      font-weight: 600;
+      padding: 1px 8px;
+      border-radius: 10px;
+      margin-left: 6px;
+      vertical-align: middle;
+    }
+  }
+}
+
+// Why section
+
+.community-why {
+  font-size: $spring-font-size-sm;
+  color: color.adjust($light-color, $lightness: 30%);
+  margin-bottom: $spring-8points * 2;
+  line-height: 1.6;
+
+  button.community-why-toggle {
+    border: 0;
+    background: none;
+    cursor: pointer;
+    color: $light-link;
+    font-size: $spring-font-size-sm;
+    padding: 0;
+    font-family: $spring-font-family;
+    text-decoration: underline;
+    font-weight: 600;
+
+    &:hover {
+      color: color.adjust($light-link, $lightness: -10%);
+    }
+  }
+
+  .community-why-content {
+    margin-top: $spring-8points;
+    padding: $spring-8points * 1.5;
+    border: 1px solid $light-border;
+    border-radius: $spring-radius;
+    background: $light-background;
+    font-size: $spring-font-size-sm;
+    color: $light-color;
+
+    p {
+      margin: 0 0 $spring-8points;
+
+      &:last-child {
+        margin-bottom: 0;
+      }
+    }
+  }
+}
+
+// Search bar
+
+.community-search {
+  margin-bottom: $spring-8points * 2;
+
+  .community-search-input-wrap {
+    position: relative;
+    display: flex;
+    align-items: center;
+    border-bottom: 3px solid $light-color;
+    padding-bottom: 2px;
+
+    &:focus-within {
+      border-color: $light-primary;
+    }
+
+    svg {
+      width: 18px;
+      height: 18px;
+      flex-shrink: 0;
+      opacity: 0.5;
+      margin-right: 8px;
+    }
+
+    input {
+      border: 0;
+      outline: none;
+      font-family: $spring-font-family;
+      font-size: $spring-font-size;
+      font-weight: 300;
+      width: 100%;
+      background: transparent;
+      padding: 0.35rem 0 0.25rem;
+      color: $light-color;
+
+      &::placeholder {
+        color: $light-color;
+        font-style: italic;
+        font-weight: 100;
+      }
+    }
+
+    .community-search-clear {
+      border: 0;
+      background: none;
+      cursor: pointer;
+      opacity: 0.4;
+      padding: 4px;
+      color: $light-color;
+      flex-shrink: 0;
+
+      svg {
+        width: 14px;
+        height: 14px;
+        margin: 0;
+      }
+
+      &:hover {
+        opacity: 0.8;
+      }
+    }
+  }
+}
+
+// Tags filter
+
+.community-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-bottom: $spring-8points * 2.5;
+
+  button.community-tag {
+    border: 1px solid $light-border;
+    border-radius: 12px;
+    background: transparent;
+    color: $light-color;
+    font-size: $spring-font-size-sm - 1;
+    font-family: $spring-font-family;
+    padding: 2px 10px;
+    cursor: pointer;
+    font-weight: 400;
+    @include transition(all $spring-transition-duration);
+
+    &:hover {
+      background: $light-background-seconday;
+    }
+
+    &.active {
+      background: $light-color;
+      color: $light-background;
+      border-color: $light-color;
+    }
+  }
+}
+
+// Results count
+
+.community-results-count {
+  font-size: $spring-font-size-sm;
+  color: color.adjust($light-color, $lightness: 30%);
+  margin-bottom: $spring-8points * 1.5;
+}
+
+// Grid
+
+.community-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+  gap: $spring-8points * 2.5;
+}
+
+// Cards
+
+.community-card {
+  border: 1px solid $light-border;
+  border-radius: $spring-radius;
+  padding: $spring-8points * 2;
+  display: flex;
+  flex-direction: column;
+  background: $light-background;
+  @include transition(box-shadow $spring-transition-duration);
+
+  &:hover {
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+  }
+
+  .community-card-name {
+    font-size: $spring-font-size + 1;
+    font-weight: 600;
+    margin: 0 0 $spring-8points * 0.75;
+    color: $light-color;
+  }
+
+  .community-card-description {
+    font-size: $spring-font-size-sm;
+    font-weight: 300;
+    color: color.adjust($light-color, $lightness: 20%);
+    line-height: 1.6;
+    margin: 0 0 $spring-8points * 1.5;
+    flex: 1;
+  }
+
+  .community-card-tags {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 4px;
+    margin-bottom: $spring-8points * 1.5;
+
+    span {
+      background: $light-background-seconday;
+      border-radius: 10px;
+      padding: 1px 8px;
+      font-size: 11px;
+      font-weight: 400;
+      color: color.adjust($light-color, $lightness: 20%);
+    }
+  }
+
+  // Snippet
+
+  .community-card-snippet {
+    margin-bottom: $spring-8points * 1.5;
+
+    .snippet-tabs {
+      display: flex;
+      gap: 0;
+      margin-bottom: 0;
+      border-bottom: 2px solid $light-border;
+
+      button.snippet-tab {
+        border: 0;
+        background: none;
+        font-family: $spring-font-family;
+        font-size: $spring-font-size-sm - 1;
+        font-weight: 600;
+        padding: 4px 12px 6px;
+        cursor: pointer;
+        color: color.adjust($light-color, $lightness: 30%);
+        text-transform: uppercase;
+        letter-spacing: 0.03em;
+        border-bottom: 3px solid transparent;
+        margin-bottom: -2px;
+        @include transition(all $spring-transition-duration);
+
+        &.active {
+          color: $light-color;
+          border-bottom-color: $light-color;
+        }
+
+        &:hover:not(.active) {
+          color: $light-color;
+        }
+      }
+    }
+
+    .snippet-content {
+      background: $light-background-seconday;
+      border-radius: 0 $spring-radius $spring-radius $spring-radius;
+      padding: $spring-8points $spring-8points * 1.5;
+      font-family: 'Courier New', Courier, monospace;
+      font-size: 12px;
+      line-height: 1.7;
+      color: $light-color;
+      overflow-x: auto;
+      white-space: pre;
+      position: relative;
+
+      button.snippet-copy {
+        position: absolute;
+        top: 6px;
+        right: 6px;
+        border: 1px solid $light-border;
+        background: $light-background;
+        border-radius: $spring-radius;
+        cursor: pointer;
+        font-family: $spring-font-family;
+        font-size: 11px;
+        padding: 2px 8px;
+        color: color.adjust($light-color, $lightness: 20%);
+        opacity: 0;
+        @include transition(opacity $spring-transition-duration);
+
+        &:hover {
+          color: $light-color;
+        }
+      }
+
+      &:hover button.snippet-copy {
+        opacity: 1;
+      }
+    }
+  }
+
+  // Links row
+
+  .community-card-links {
+    display: flex;
+    gap: $spring-8points;
+
+    a {
+      font-size: $spring-font-size-sm - 1;
+      font-weight: 600;
+      color: $light-link;
+      text-decoration: none;
+      text-transform: uppercase;
+      letter-spacing: 0.04em;
+      padding: 4px 0;
+      border-bottom: 2px solid transparent;
+      @include transition(border-color $spring-transition-duration);
+
+      &:hover {
+        border-bottom-color: $light-link;
+      }
+    }
+  }
+}
+
+// Empty state
+
+.community-empty {
+  text-align: center;
+  padding: $spring-8points * 6 0;
+  color: color.adjust($light-color, $lightness: 40%);
+
+  p {
+    margin: $spring-8points 0 0;
+    font-size: $spring-font-size-sm;
+  }
+}
+
+// Transitions (matching popup/modal patterns in the project)
+
+.community-enter {
+  opacity: 0;
+}
+
+.community-enter-active {
+  opacity: 1;
+  transition: all 300ms;
+}
+
+.community-exit {
+  opacity: 1;
+}
+
+.community-exit-active {
+  opacity: 0;
+  transition: all 300ms;
+}
+
+// Dark theme overrides
+
+.dark {
+  .modal-community-container {
+    background: #1b1f23;
+    color: white;
+    border: 1px solid $dark-border;
+  }
+
+  .modal-community .modal-header {
+    border-bottom-color: $dark-border;
+  }
+
+  .modal-community .modal-action {
+    border-top-color: $dark-border;
+  }
+
+  .community-notice {
+    background: $dark-background-secondary;
+
+    p {
+      color: $dark-color;
+    }
+
+    .community-notice-boot {
+      color: $dark-color;
+    }
+  }
+
+  .community-why {
+    color: color.adjust($dark-color, $lightness: -30%);
+
+    .community-why-content {
+      background: $dark-background-secondary;
+      border-color: $dark-border;
+      color: $dark-color;
+    }
+  }
+
+  .community-search {
+    .community-search-input-wrap {
+      border-color: $dark-color;
+
+      input {
+        color: $dark-color;
+        background: transparent;
+
+        &::placeholder {
+          color: color.adjust($dark-color, $lightness: -30%);
+        }
+      }
+
+      svg {
+        color: $dark-color;
+      }
+
+      .community-search-clear {
+        color: $dark-color;
+      }
+    }
+  }
+
+  .community-tags button.community-tag {
+    border-color: $dark-border;
+    color: $dark-color;
+
+    &:hover {
+      background: $dark-background-secondary;
+    }
+
+    &.active {
+      background: $dark-color;
+      color: $dark-background;
+    }
+  }
+
+  .community-results-count {
+    color: color.adjust($dark-color, $lightness: -30%);
+  }
+
+  .community-card {
+    background: $dark-background-secondary;
+    border-color: $dark-border;
+
+    .community-card-name {
+      color: $dark-color;
+    }
+
+    .community-card-description {
+      color: color.adjust($dark-color, $lightness: -20%);
+    }
+
+    .community-card-tags span {
+      background: color.adjust($dark-background-secondary, $lightness: 5%);
+      color: color.adjust($dark-color, $lightness: -20%);
+    }
+
+    .snippet-tabs button.snippet-tab {
+      color: color.adjust($dark-color, $lightness: -20%);
+
+      &.active {
+        color: $dark-color;
+        border-bottom-color: $dark-color;
+      }
+    }
+
+    .snippet-content {
+      background: $dark-background;
+      color: $dark-color;
+
+      button.snippet-copy {
+        background: $dark-background-secondary;
+        border-color: $dark-border;
+        color: color.adjust($dark-color, $lightness: -20%);
+
+        &:hover {
+          color: $dark-color;
+        }
+      }
+    }
+
+    .community-card-links a {
+      color: color.adjust($dark-link, $lightness: 20%);
+
+      &:hover {
+        border-bottom-color: color.adjust($dark-link, $lightness: 20%);
+      }
+    }
+  }
+
+  .community-empty {
+    color: color.adjust($dark-color, $lightness: -30%);
+  }
+}


### PR DESCRIPTION
This PR proposes an alternative approach to Issue #185.

Rather than linking users to an external page of third-party starters, it introduces a dedicated "Community-Maintained Starters" experience within the start.spring.io UI.

## Motivation

PR #261 previously attempted to address this issue by adding a Help menu link to an external starter catalog. During review, concerns were raised that the relationship between the selected Spring Boot version and the linked starter information was not obvious.

This implementation keeps users within start.spring.io and provides additional context around community-maintained starters.

## What Changed

* Added a new Community-Maintained Starters view accessible from the Help menu
* Added a curated starter catalog backed by static metadata
* Added search and tag filtering
* Added Maven and Gradle dependency snippets
* Displayed the currently selected Spring Boot version with guidance to verify compatibility through each project's documentation
* Added unit tests for catalog integrity and filtering behavior

## Notes

The catalog is intentionally small and serves as a discovery mechanism for community-maintained starters that are not part of the curated Initializr dependency catalog.

Compatibility remains the responsibility of each starter project and users are directed to official project documentation for verification.

The initial catalog contains a limited set of well-established community-maintained starters and is not intended to be exhaustive. The metadata-driven approach is designed to scale incrementally, allowing additional community-maintained starters to be proposed and reviewed through the normal pull request process without requiring changes to the UI implementation.

