### PR TITLE
Upgrade to Spring Cloud 2025.1.3

### DIFF
--- a/start-site/src/main/java/io/spring/start/site/extension/dependency/springcloud/SpringCloudContractGradleBuildCustomizer.java
+++ b/start-site/src/main/java/io/spring/start/site/extension/dependency/springcloud/SpringCloudContractGradleBuildCustomizer.java
@@ -48,6 +48,15 @@ abstract class SpringCloudContractGradleBuildCustomizer implements BuildCustomiz
 		.snapshotsEnabled(true)
 		.build();
 
+	private static final String CONTRACT_VERIFIER_DEPENDENCY_ID = "org.springframework.cloud:spring-cloud-contract-verifier";
+
+	/**
+	 * As of the {@code 2025.1.3} Spring Cloud release train, Spring Cloud Contract is no
+	 * longer part of {@code spring-cloud-dependencies}. Fall back to the dedicated
+	 * {@code spring-cloud-contract} bom.
+	 */
+	private static final String CONTRACT_BOM_NAME = "spring-cloud-contract";
+
 	private final ProjectDescription description;
 
 	private final SpringCloudProjectVersionResolver projectsVersionResolver;
@@ -61,8 +70,7 @@ abstract class SpringCloudContractGradleBuildCustomizer implements BuildCustomiz
 	@Override
 	public void customize(GradleBuild build) {
 		Version platformVersion = this.description.getPlatformVersion();
-		String sccPluginVersion = this.projectsVersionResolver.resolveVersion(platformVersion,
-				"org.springframework.cloud:spring-cloud-contract-verifier");
+		String sccPluginVersion = resolveSccPluginVersion(platformVersion);
 		if (sccPluginVersion == null) {
 			logger.warn(
 					"Spring Cloud Contract Verifier Gradle plugin version could not be resolved for Spring Boot version: "
@@ -79,6 +87,16 @@ abstract class SpringCloudContractGradleBuildCustomizer implements BuildCustomiz
 		}
 		build.tasks().customize("contractTest", (task) -> task.invoke("useJUnitPlatform"));
 		configurePluginRepositories(build, sccPluginVersion);
+	}
+
+	private String resolveSccPluginVersion(Version platformVersion) {
+		String sccPluginVersion = this.projectsVersionResolver.resolveVersion(platformVersion,
+				CONTRACT_VERIFIER_DEPENDENCY_ID);
+		if (sccPluginVersion != null) {
+			return sccPluginVersion;
+		}
+		return this.projectsVersionResolver.resolveVersion(CONTRACT_BOM_NAME, platformVersion,
+				CONTRACT_VERIFIER_DEPENDENCY_ID);
 	}
 
 	protected abstract void configureContractsDsl(GradleBuild build);

--- a/start-site/src/main/java/io/spring/start/site/extension/dependency/springcloud/SpringCloudContractMavenBuildCustomizer.java
+++ b/start-site/src/main/java/io/spring/start/site/extension/dependency/springcloud/SpringCloudContractMavenBuildCustomizer.java
@@ -48,6 +48,15 @@ class SpringCloudContractMavenBuildCustomizer implements BuildCustomizer<MavenBu
 		.snapshotsEnabled(true)
 		.build();
 
+	private static final String CONTRACT_VERIFIER_DEPENDENCY_ID = "org.springframework.cloud:spring-cloud-contract-verifier";
+
+	/**
+	 * As of the {@code 2025.1.3} Spring Cloud release train, Spring Cloud Contract is no
+	 * longer part of {@code spring-cloud-dependencies}. Fall back to the dedicated
+	 * {@code spring-cloud-contract} bom.
+	 */
+	private static final String CONTRACT_BOM_NAME = "spring-cloud-contract";
+
 	private final ProjectDescription description;
 
 	private final SpringCloudProjectVersionResolver projectsVersionResolver;
@@ -61,8 +70,7 @@ class SpringCloudContractMavenBuildCustomizer implements BuildCustomizer<MavenBu
 	@Override
 	public void customize(MavenBuild mavenBuild) {
 		Version platformVersion = this.description.getPlatformVersion();
-		String sccPluginVersion = this.projectsVersionResolver.resolveVersion(platformVersion,
-				"org.springframework.cloud:spring-cloud-contract-verifier");
+		String sccPluginVersion = resolveSccPluginVersion(platformVersion);
 		if (sccPluginVersion == null) {
 			logger.warn(
 					"Spring Cloud Contract Verifier Maven plugin version could not be resolved for Spring Boot version: "
@@ -81,6 +89,16 @@ class SpringCloudContractMavenBuildCustomizer implements BuildCustomizer<MavenBu
 			}
 		});
 		configurePluginRepositories(mavenBuild, sccPluginVersion);
+	}
+
+	private String resolveSccPluginVersion(Version platformVersion) {
+		String sccPluginVersion = this.projectsVersionResolver.resolveVersion(platformVersion,
+				CONTRACT_VERIFIER_DEPENDENCY_ID);
+		if (sccPluginVersion != null) {
+			return sccPluginVersion;
+		}
+		return this.projectsVersionResolver.resolveVersion(CONTRACT_BOM_NAME, platformVersion,
+				CONTRACT_VERIFIER_DEPENDENCY_ID);
 	}
 
 	private void configurePluginRepositories(MavenBuild mavenBuild, String sccPluginVersion) {

--- a/start-site/src/main/java/io/spring/start/site/extension/dependency/springcloud/SpringCloudProjectVersionResolver.java
+++ b/start-site/src/main/java/io/spring/start/site/extension/dependency/springcloud/SpringCloudProjectVersionResolver.java
@@ -44,7 +44,7 @@ class SpringCloudProjectVersionResolver {
 
 	/**
 	 * Resolve the version of a specified artifact that matches the provided Spring Boot
-	 * version.
+	 * version, using the {@code spring-cloud} bom.
 	 * @param platformVersion the Spring Boot version to check the Spring Cloud Release
 	 * train version against
 	 * @param dependencyId the dependency id of the Spring Cloud artifact in the form of
@@ -52,15 +52,26 @@ class SpringCloudProjectVersionResolver {
 	 * @return the appropriate project version or {@code null} if the resolution failed
 	 */
 	String resolveVersion(Version platformVersion, String dependencyId) {
-		BillOfMaterials bom = this.metadata.getConfiguration().getEnv().getBoms().get("spring-cloud");
+		return resolveVersion("spring-cloud", platformVersion, dependencyId);
+	}
+
+	/**
+	 * Resolve the version of a specified artifact that matches the provided Spring Boot
+	 * version, using the bom registered under the given name.
+	 * @param bomName the name of the bom, as registered in the initializr metadata
+	 * @param platformVersion the Spring Boot version to check the bom's version against
+	 * @param dependencyId the dependency id of the artifact managed by the bom, in the
+	 * form of {@code groupId:artifactId}
+	 * @return the appropriate project version or {@code null} if the resolution failed
+	 */
+	String resolveVersion(String bomName, Version platformVersion, String dependencyId) {
+		BillOfMaterials bom = this.metadata.getConfiguration().getEnv().getBoms().get(bomName);
 		if (bom == null) {
 			return null;
 		}
-		String releaseTrainVersion = bom.resolve(platformVersion).getVersion();
-		logger.info("Retrieving version for artifact: " + dependencyId + " and release train version: "
-				+ releaseTrainVersion);
-		return this.versionResolver
-			.resolveDependencies("org.springframework.cloud", "spring-cloud-dependencies", releaseTrainVersion)
+		String bomVersion = bom.resolve(platformVersion).getVersion();
+		logger.info("Retrieving version for artifact: " + dependencyId + " and bom version: " + bomVersion);
+		return this.versionResolver.resolveDependencies(bom.getGroupId(), bom.getArtifactId(), bomVersion)
 			.get(dependencyId);
 	}
 

--- a/start-site/src/main/resources/application.yml
+++ b/start-site/src/main/resources/application.yml
@@ -105,7 +105,7 @@ initializr:
         order: 50
         mappings:
           - compatibilityRange: "[4.0.0,4.2.0-M1)"
-            version: 2025.1.2
+            version: 2025.1.3
       spring-cloud-azure:
         groupId: com.azure.spring
         artifactId: spring-cloud-azure-dependencies

--- a/start-site/src/main/resources/application.yml
+++ b/start-site/src/main/resources/application.yml
@@ -106,6 +106,13 @@ initializr:
         mappings:
           - compatibilityRange: "[4.0.0,4.2.0-M1)"
             version: 2025.1.3
+      spring-cloud-contract:
+        groupId: org.springframework.cloud
+        artifactId: spring-cloud-contract-dependencies
+        versionProperty: spring-cloud-contract.version
+        mappings:
+          - compatibilityRange: "[4.0.0,4.2.0-M1)"
+            version: 5.0.3
       spring-cloud-azure:
         groupId: com.azure.spring
         artifactId: spring-cloud-azure-dependencies
@@ -1354,7 +1361,7 @@ initializr:
             - rel: reference
               href: https://java.testcontainers.org/
         - name: Contract Verifier
-          bom: spring-cloud
+          bom: spring-cloud-contract
           compatibilityRange: "[4.0.0,4.2.0-M1)"
           id: cloud-contract-verifier
           description: Moves TDD to the level of software architecture by enabling Consumer Driven Contract (CDC) development.
@@ -1365,7 +1372,7 @@ initializr:
             - rel: reference
               href: https://docs.spring.io/spring-cloud-contract/reference/
         - name: Contract Stub Runner
-          bom: spring-cloud
+          bom: spring-cloud-contract
           compatibilityRange: "[4.0.0,4.2.0-M1)"
           id: cloud-contract-stub-runner
           description: Stub Runner for HTTP/Messaging based communication. Allows creating WireMock stubs from RestDocs tests.


### PR DESCRIPTION
Generated by the [post release workflow](https://github.com/spring-cloud/spring-cloud-github-actions/actions/runs/32407476372).

Spring Cloud 2025.1.3 has been released, so the `spring-cloud` bom mapping for the 2025.1 line moves from `2025.1.2` to `2025.1.3`. The `compatibilityRange` is unchanged.