### PR TITLE
Provide ojdbc17 instead of ojdbc11

### DIFF
--- a/start-site/src/main/resources/application.yml
+++ b/start-site/src/main/resources/application.yml
@@ -774,7 +774,7 @@ initializr:
           id: oracle
           description: A JDBC driver that provides access to Oracle.
           groupId: com.oracle.database.jdbc
-          artifactId: ojdbc11
+          artifactId: ojdbc17
           scope: runtime
           starter: false
         - name: PostgreSQL Driver


### PR DESCRIPTION
Similar to #1366 , since we are on JDK 17 at minimum, we should use the `ojdbc17` instead of `ojdbc11` variant by default I think.  This is the Oracle description for `ojdbc17`:

> Supports JDBC 4.3 spec and for use with JDK21, JDK19, and JDK17. Compatible with the Jakarta APIs. (Starting from 23.6)