### PR TITLE
Derive known Java ceiling from JavaVersionMapping

### DIFF
--- a/start-site/src/main/java/io/spring/start/site/project/JavaVersionMapping.java
+++ b/start-site/src/main/java/io/spring/start/site/project/JavaVersionMapping.java
@@ -65,6 +65,14 @@ class JavaVersionMapping {
 		return findMapping(springBootVersion).kotlinVersion();
 	}
 
+	/**
+	 * Returns the highest Java version known by the mappings.
+	 * @return the maximum known Java version
+	 */
+	int getMaxKnownJavaVersion() {
+		return mappings.stream().mapToInt(Mapping::maxJavaVersion).max().orElseThrow();
+	}
+
 	private Mapping findMapping(Version springBootVersion) {
 		for (Mapping mapping : mappings) {
 			if (mapping.match(springBootVersion)) {

--- a/start-site/src/main/java/io/spring/start/site/project/JavaVersionProjectDescriptionCustomizer.java
+++ b/start-site/src/main/java/io/spring/start/site/project/JavaVersionProjectDescriptionCustomizer.java
@@ -42,8 +42,6 @@ public class JavaVersionProjectDescriptionCustomizer implements ProjectDescripti
 
 	private static final String LEGACY_VERSION_PREFIX = "1.";
 
-	private static final int MAX_JAVA_VERSION = 26;
-
 	private static final String JDK_VERSION_RANGE_WIKI = "https://github.com/spring-projects/spring-framework/wiki/Spring-Framework-Versions#jdk-version-range";
 
 	private final JavaVersionMapping javaVersionMapping = new JavaVersionMapping();
@@ -123,7 +121,7 @@ public class JavaVersionProjectDescriptionCustomizer implements ProjectDescripti
 		try {
 			int parsedGeneration = Integer.parseInt(generation);
 			// A version beyond the ones we know about is left as is
-			return (parsedGeneration <= MAX_JAVA_VERSION) ? parsedGeneration : null;
+			return (parsedGeneration <= this.javaVersionMapping.getMaxKnownJavaVersion()) ? parsedGeneration : null;
 		}
 		catch (NumberFormatException ex) {
 			return null;

--- a/start-site/src/test/java/io/spring/start/site/project/JavaVersionMappingTests.java
+++ b/start-site/src/test/java/io/spring/start/site/project/JavaVersionMappingTests.java
@@ -18,6 +18,7 @@ package io.spring.start.site.project;
 
 import io.spring.initializr.generator.version.Version;
 import io.spring.initializr.generator.version.VersionParser;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
@@ -52,6 +53,11 @@ class JavaVersionMappingTests {
 	@ParameterizedTest(name = "Spring Boot {0} | Kotlin {1}")
 	void kotlinVersion(String bootVersion, String expectedKotlinVersion) {
 		assertThat(this.mapping.getKotlinVersion(toVersion(bootVersion))).isEqualTo(toVersion(expectedKotlinVersion));
+	}
+
+	@Test
+	void maxKnownJavaVersion() {
+		assertThat(this.mapping.getMaxKnownJavaVersion()).isEqualTo(27);
 	}
 
 	private Version toVersion(String version) {

--- a/start-site/src/test/java/io/spring/start/site/project/JavaVersionProjectDescriptionCustomizerTests.java
+++ b/start-site/src/test/java/io/spring/start/site/project/JavaVersionProjectDescriptionCustomizerTests.java
@@ -125,6 +125,34 @@ class JavaVersionProjectDescriptionCustomizerTests extends AbstractExtensionTest
 		assertHelpDocument("${another.version}").doesNotContain("# Read Me First");
 	}
 
+	@Test
+	void java27IsDowngradedTo26OnBoot40() {
+		ProjectRequest request = createProjectRequest(SupportedBootVersion.V4_0, "web");
+		request.setJavaVersion("27");
+		assertThat(mavenPom(request)).hasProperty("java.version", "26");
+	}
+
+	@Test
+	void java27IsDowngradedTo26OnBoot41() {
+		ProjectRequest request = createProjectRequest(SupportedBootVersion.V4_1, "web");
+		request.setJavaVersion("27");
+		assertThat(mavenPom(request)).hasProperty("java.version", "26");
+	}
+
+	@Test
+	void java27IsSupportedOnBoot42() {
+		assertThat(mavenPom(javaProject("27", "4.2.0"))).hasProperty("java.version", "27");
+	}
+
+	@Test
+	void warningAddedWhenJava27IsDowngraded() {
+		ProjectRequest request = createProjectRequest(SupportedBootVersion.V4_0, "web");
+		request.setJavaVersion("27");
+		assertThat(helpDocument(request)).lines()
+			.containsSubsequence("# Read Me First",
+					"* The JVM level was changed to '26', review the [JDK Version Range](https://github.com/spring-projects/spring-framework/wiki/Spring-Framework-Versions#jdk-version-range) on the wiki for more details.");
+	}
+
 	private TextAssert assertHelpDocument(ProjectRequest request) {
 		return assertThat(helpDocument(request));
 	}


### PR DESCRIPTION
Derive the known-Java ceiling from `JavaVersionMapping` instead of the hardcoded `MAX_JAVA_VERSION`, so the two cannot drift again.

Fixes #2280